### PR TITLE
fix: add Google service account credentials to CI for Sheets reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,11 @@ jobs:
     - name: Setup database
       run: python scripts/setup_database.py
 
+    - name: Setup Google credentials
+      env:
+        GOOGLE_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CREDENTIALS_JSON }}
+      run: echo "$GOOGLE_CREDENTIALS_JSON" > google-credentials.json
+
     - name: Run vendor isolation tests with Google Sheets reporting
       env:
         GOOGLE_SHEETS_ID: ${{ secrets.GOOGLE_SHEETS_ID }}


### PR DESCRIPTION
## fix: add Google service account credentials to CI pipeline

**Prerequisite:** Add GOOGLE_CREDENTIALS_JSON as a repository secret (Settings → Secrets → Actions)."

### Problem
The Google Sheets reporter plugin authenticates using a service account credentials file (google-credentials.json), but CI only passes the GOOGLE_SHEETS_ID secret. Without the credentials file on disk, the plugin silently fails to connect — tests pass, but results are never written to Google Sheets.

### Changes
- Added a Setup Google credentials step to .github/workflows/test.yml that writes the GOOGLE_CREDENTIALS_JSON secret to google-credentials.json before test execution

### Prerequisites
The GOOGLE_CREDENTIALS_JSON repository secret must be configured:
**Settings → Secrets and variables → Actions → New repository secret**
Paste the full contents of the Google service account JSON key file.

### Testing
- CI test steps with --google-sheets flag should now report results to the configured Google Sheet
- Verify worksheets (Isolation Testing Framework TCs, Secure Session Management, Summary) are updated after a pipeline run