### PR TITLE
fix: validate due date is not earlier than invoice date

### DIFF
--- a/finbot/static/css/vendor/portal.css
+++ b/finbot/static/css/vendor/portal.css
@@ -531,6 +531,16 @@ body {
     color: var(--text-secondary);
 }
 
+.vendor-input.border-red-400 {
+    border-color: #f87171 !important;
+    box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.15);
+}
+
+.vendor-input.border-red-400:focus {
+    border-color: #f87171 !important;
+    box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.25);
+}
+
 /* ==========================================================================
    CHAT INTERFACE
    ========================================================================== */

--- a/finbot/static/js/vendor/invoice.js
+++ b/finbot/static/js/vendor/invoice.js
@@ -162,6 +162,7 @@ function initializeInvoiceModal() {
         const dueDate = new Date();
         dueDate.setDate(dueDate.getDate() + 30);
         dueDateInput.value = formatDateForInput(dueDate);
+        dueDateInput.addEventListener('change', () => clearFieldError(dueDateInput));
     }
 }
 
@@ -256,7 +257,9 @@ async function handleInvoiceSubmit(e) {
             invoice_date: formData.get('invoice_date'),
             due_date: formData.get('due_date')
         };
-
+        
+        clearAllFieldErrors(form);
+        
         // Validate data
         if (!invoiceData.invoice_number || !invoiceData.amount || !invoiceData.description) {
             hideLoading();
@@ -268,6 +271,16 @@ async function handleInvoiceSubmit(e) {
             hideLoading();
             showNotification('Amount must be greater than zero', 'error');
             return;
+        }
+
+        if (invoiceData.invoice_date && invoiceData.due_date) {
+            if (new Date(invoiceData.due_date) < new Date(invoiceData.invoice_date)) {
+                hideLoading();
+                const dueDateField = document.getElementById('invoice-due-date');
+                showFieldError(dueDateField, 'Due date cannot be earlier than invoice date');
+                showNotification('Due date cannot be earlier than invoice date', 'error');
+                return;
+            }
         }
 
         let response;
@@ -296,6 +309,7 @@ async function handleInvoiceSubmit(e) {
         ]);
 
     } catch (error) {
+        hideLoading();
         console.error('Error saving invoice:', error);
 
         // Handle API errors


### PR DESCRIPTION
Close #74 
## Summary

- Add frontend validation in `handleInvoiceSubmit` to block form submission when due date is earlier than invoice date
- Highlight invalid date fields with red border and inline error message using existing `showFieldError`/`clearFieldError` utilities


https://github.com/user-attachments/assets/1a9e2b19-5a2a-4fa6-974f-0d0666063d4e

