### PR TITLE
fix(ui):prevent logout button overflow with long emails in sidebar

### DIFF
--- a/finbot/apps/ctf/templates/base.html
+++ b/finbot/apps/ctf/templates/base.html
@@ -148,9 +148,9 @@
             <div class="p-6 border-t border-ctf-primary/20">
                 {% if session_context and session_context.email %}
                 <!-- Signed In User -->
-                <div class="flex items-center justify-between mb-3">
-                    <div class="flex items-center space-x-3">
-                        <div class="w-10 h-10 rounded-full bg-gradient-to-r from-ctf-accent to-ctf-primary flex items-center justify-center text-sm font-bold text-portal-bg-primary">
+                <div class="flex items-center justify-between gap-2 mb-3">
+                    <div class="flex items-center space-x-3 min-w-0">
+                        <div class="w-10 h-10 shrink-0 rounded-full bg-gradient-to-r from-ctf-accent to-ctf-primary flex items-center justify-center text-sm font-bold text-portal-bg-primary">
                             {{ session_context.email[0]|upper }}
                         </div>
                         <div class="min-w-0 flex-1">
@@ -158,7 +158,7 @@
                             <div class="text-xs text-ctf-primary font-mono" id="sidebar-points">-- pts</div>
                         </div>
                     </div>
-                    <a href="/auth/logout" class="p-2 rounded-lg bg-portal-bg-tertiary border border-ctf-primary/20 text-text-secondary hover:text-ctf-primary hover:border-ctf-primary/40 transition-colors">
+                    <a href="/auth/logout" class="shrink-0 p-2 rounded-lg bg-portal-bg-tertiary border border-ctf-primary/20 text-text-secondary hover:text-ctf-primary hover:border-ctf-primary/40 transition-colors">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
                         </svg>

--- a/finbot/apps/vendor/templates/base.html
+++ b/finbot/apps/vendor/templates/base.html
@@ -184,9 +184,9 @@
 
                 {% if session_context and session_context.email %}
                 <!-- Signed In User -->
-                <div class="flex items-center justify-between">
-                    <div class="flex items-center space-x-3">
-                        <div class="w-10 h-10 rounded-full bg-gradient-to-r from-vendor-accent to-vendor-primary flex items-center justify-center text-sm font-bold text-portal-bg-primary">
+                <div class="flex items-center justify-between gap-2">
+                    <div class="flex items-center space-x-3 min-w-0">
+                        <div class="w-10 h-10 shrink-0 rounded-full bg-gradient-to-r from-vendor-accent to-vendor-primary flex items-center justify-center text-sm font-bold text-portal-bg-primary">
                             {{ session_context.email[0]|upper }}
                         </div>
                         <div class="min-w-0 flex-1">
@@ -194,7 +194,7 @@
                             <div class="text-xs text-vendor-accent">Signed In</div>
                         </div>
                     </div>
-                    <a href="/auth/logout" class="vendor-btn quantum-secondary text-xs px-3 py-2">
+                    <a href="/auth/logout" class="shrink-0 vendor-btn quantum-secondary text-xs px-3 py-2">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
                         </svg>


### PR DESCRIPTION
close #107
## Summary
 - Add `min-w-0` to the email+avatar flex container so it can shrink and allow **email truncation**
 - Add `shrink-0` to the avatar and logout button to prevent them from being compressed
 - Add `gap-2` for consistent spacing between email and logout button
 
> Fixes both vendor and CTF portal sidebars (base.html).

**before**
<img width="318" height="77" alt="logout-1" src="https://github.com/user-attachments/assets/c656804f-b691-4226-81eb-7f7b056ccdaf" />
**after**
<img width="316" height="168" alt="logout-3" src="https://github.com/user-attachments/assets/722ce7e3-ce8a-4b53-b9e2-65711129a0d6" />

