### PR TITLE
fix: preserve button innerHTML in showLoading to fix modal reopen bug

### DIFF
--- a/finbot/static/js/common/utils.js
+++ b/finbot/static/js/common/utils.js
@@ -527,13 +527,13 @@ function clearAllFieldErrors(form) {
  */
 function showLoading(element, text = 'Loading...') {
     element.classList.add('loading');
-    const originalText = element.textContent;
+    const originalHTML = element.innerHTML;
     element.textContent = text;
     element.disabled = true;
 
     return () => {
         element.classList.remove('loading');
-        element.textContent = originalText;
+        element.innerHTML = originalHTML;
         element.disabled = false;
     };
 }


### PR DESCRIPTION
close #112 

maybe this was cause for issue #36  
### Problem

After successfully creating an invoice, clicking "Create Invoice" again did nothing. The modal would not open and a page 
reload was required.

### Root Cause

`showLoading()` in `utils.js` used `element.textContent = text` which wiped all child elements inside the submit button, including `<span id="submit-invoice-text">`. On the next modal open, `document.getElementById('submit-invoice-text')` returned `null`, throwing a `TypeError` before the modal was shown.


https://github.com/user-attachments/assets/3572df25-b70f-4c35-b0d7-9aad4b323239

