### PR TITLE
Fix database session leak in get_invoice_details() when invoice not found

### DIFF
--- a/finbot/tools/data/invoice.py
+++ b/finbot/tools/data/invoice.py
@@ -24,11 +24,14 @@ async def get_invoice_details(
     """
     logger.info("Getting invoice details for invoice_id: %s", invoice_id)
     db = next(get_db())
-    invoice_repo = InvoiceRepository(db, session_context)
-    invoice = invoice_repo.get_invoice(invoice_id)
-    if not invoice:
-        raise ValueError("Invoice not found")
-    return invoice.to_dict()
+    try:
+        invoice_repo = InvoiceRepository(db, session_context)
+        invoice = invoice_repo.get_invoice(invoice_id)
+        if not invoice:
+            raise ValueError("Invoice not found")
+        return invoice.to_dict()
+    finally:
+        db.close()
 
 
 async def update_invoice_status(


### PR DESCRIPTION
## Summary
Fixes a database session leak in `get_invoice_details()` that occurs when an invoice ID is not found, preventing connection pool exhaustion under load.

## Problem
When `get_invoice_details()` is called with a non-existent invoice ID:
1. A database session is obtained via `next(get_db())`
2. The repository returns `None` for the invoice
3. `ValueError("Invoice not found")` is raised
4. `db.close()` is never called, leaving the session open

This creates a denial-of-service vector where repeated invalid invoice lookups exhaust the database connection pool, blocking all database operations.

## Solution
Wrap the database operations in a try/finally block to ensure the session is always closed, even when exceptions occur:

```python
db = next(get_db())
try:
    # database operations
    return result
finally:
    db.close()