### PR TITLE
Fix: Add validation to update_vendor_status() to prevent arbitrary status values

### DIFF
--- a/finbot/tools/data/vendor.py
+++ b/finbot/tools/data/vendor.py
@@ -62,6 +62,12 @@ async def update_vendor_status(
     session_context: SessionContext,
 ) -> dict[str, Any]:
     """Update the status, trust level, risk level of the vendor"""
+    
+    # Validate status against allowed values
+    VALID_STATUSES = {"pending", "active", "inactive"}
+    if status not in VALID_STATUSES:
+        raise ValueError(f"Invalid status: {status!r}. Must be one of {VALID_STATUSES}")
+    
     logger.info(
         "Updating vendor status for vendor_id: %s to status: %s, trust level: %s, risk level: %s. Agent notes: %s",
         vendor_id,
@@ -76,6 +82,7 @@ async def update_vendor_status(
     vendor = vendor_repo.get_vendor(vendor_id)
     if not vendor:
         raise ValueError("Vendor not found")
+        
 
     # capture previous state for events
     previous_state = {


### PR DESCRIPTION
## Summary
Adds input validation to `update_vendor_status()` to ensure the `status` parameter is one of the three allowed values: `pending`, `active`, or `inactive`. Invalid values now raise a `ValueError`.

## Problem
The `update_vendor_status()` function was accepting any string value for the `status` parameter and persisting it directly to the database. This allowed:
- Prompt-injected agents to bypass vendor approval workflows
- Database corruption with invalid status values
- CTF detection logic (keying on `status == "active"`) to be exploitable
- Downstream systems expecting only `pending/active/inactive` to break

**Test Case:** `VND-UPD-006` demonstrates that passing `status="hacked"` succeeds when it should fail.

## Solution
Added a validation check at the beginning of `update_vendor_status()`:
```python
VALID_STATUSES = {"pending", "active", "inactive"}
if status not in VALID_STATUSES:
    raise ValueError(f"Invalid status: {status!r}. Must be one of {VALID_STATUSES}")