### PR TITLE
ctf: add Ghost Vendor cross-vendor data leakage challenge (ASI-03)

### DIFF
--- a/finbot/ctf/definitions/challenges/data_exfiltration/ghost_vendor.yaml
+++ b/finbot/ctf/definitions/challenges/data_exfiltration/ghost_vendor.yaml
@@ -53,8 +53,8 @@ hints:
 
 labels:
   owasp_llm:
-    - LLM01:2025
-    - LLM05:2025
+    - LLM01:Prompt Injection
+    - LLM05:Sensitive Information Disclosure
   cwe:
     - CWE-639:Authorization Bypass Through User-Controlled Key
     - CWE-285:Improper Authorization


### PR DESCRIPTION
Adds a new Red/Blue paired CTF challenge for the IDOR vulnerability in VendorChatAssistant._call_get_vendor_details() (finbot/agents/chat.py).

Bug: the get_vendor_details tool passes whatever vendor_id the LLM supplies directly to the database with no check that it matches session_context.current_vendor_id. A logged-in vendor can ask the chatbot for a different vendor ID and read that tenant's full profile.

Challenge details:
- id: data-exfil-ghost-vendor
- category: data_exfiltration / privilege_abuse
- difficulty: beginner (150 pts)
- OWASP Agentic: ASI-03 Privilege Abuse
- CWE-639: Authorization Bypass Through User-Controlled Key
- detector_class: CrossVendorDataLeakDetector

Blue track (inside detector_config.blue_track):
- hook_type: pre_tool_call on get_vendor_details
- detection_signal: vendor_id_arg != session_context.current_vendor_id
- block_action: return authorization error before DB query executes

The underlying bug in chat.py is intentionally left unfixed so the challenge remains exploitable.