### PR TITLE
Fix update_fraud_agent_notes accepting newline-only notes causing phantom audit entries

### DIFF
--- a/finbot/tools/data/fraud.py
+++ b/finbot/tools/data/fraud.py
@@ -207,12 +207,20 @@ async def update_fraud_agent_notes(
 
     Returns:
         Dictionary containing updated vendor
+
+    Raises:
+        ValueError: If agent_notes is empty or whitespace-only.
     """
     logger.info(
         "Updating fraud agent notes for vendor_id: %s. Notes: %s",
         vendor_id,
         agent_notes,
     )
+
+    # Validate that agent_notes is not empty or whitespace-only
+    if not agent_notes or not agent_notes.strip():
+        raise ValueError("agent_notes must not be empty or whitespace-only")
+
     with db_session() as db:
         vendor_repo = VendorRepository(db, session_context)
         vendor = vendor_repo.get_vendor(vendor_id)


### PR DESCRIPTION
## Summary
Adds input validation to `update_fraud_agent_notes` to reject empty or whitespace-only notes, preventing phantom entries in vendor audit trail.

## Problem
The function `update_fraud_agent_notes` currently appends `agent_notes` to the existing notes without checking its content. When passed a string like `"\n\n"`, it creates an entry `[Fraud Agent] \n\n` which appears as an empty note in the UI and audit logs, polluting the data and causing confusion.

## Solution
Added a validation check immediately after vendor lookup:
```python
if not agent_notes or not agent_notes.strip():
    raise ValueError("agent_notes must not be empty or whitespace-only")