### PR TITLE
fix: validate risk_level in update_vendor_risk against allowed values

### DIFF
--- a/finbot/tools/data/fraud.py
+++ b/finbot/tools/data/fraud.py
@@ -95,6 +95,9 @@ async def update_vendor_risk(
 
     Returns:
         Dictionary containing updated vendor details
+
+    Raises:
+        ValueError: If risk_level is not one of the allowed values.
     """
     logger.info(
         "Updating vendor risk for vendor_id: %s to risk_level: %s. Notes: %s",
@@ -102,6 +105,14 @@ async def update_vendor_risk(
         risk_level,
         agent_notes,
     )
+
+    # Validate risk_level against allowed values
+    VALID_RISK_LEVELS = {"low", "medium", "high"}
+    if risk_level not in VALID_RISK_LEVELS:
+        raise ValueError(
+            f"Invalid risk_level: {risk_level!r}. Must be one of {VALID_RISK_LEVELS}"
+        )
+
     with db_session() as db:
         vendor_repo = VendorRepository(db, session_context)
         vendor = vendor_repo.get_vendor(vendor_id)
@@ -128,7 +139,6 @@ async def update_vendor_risk(
         result = vendor.to_dict()
         result["_previous_state"] = previous_state
         return result
-
 
 async def flag_invoice_for_review(
     invoice_id: int,


### PR DESCRIPTION
## Summary
Adds input validation to `update_vendor_risk` to ensure `risk_level` is one of the allowed strings: `'low'`, `'medium'`, `'high'`.

## Problem
The function currently accepts any string (e.g., `" low"`) and persists it directly, causing downstream fraud detection logic that relies on exact matches to fail. This can lead to silent data corruption and incorrect fraud assessments.

## Solution
- Defined a set `VALID_RISK_LEVELS = {"low", "medium", "high"}`.
- Immediately after logging, check if `risk_level` is in this set.
- Raise a `ValueError` with a clear message if validation fails.
- Updated the docstring to reflect the exception.

## Impact
- Prevents invalid risk levels from being stored.
- No breaking changes for valid inputs.
- Improves data integrity and aligns the function with its documented behavior.

## Testing
- Added validation logic and verified that:
  - `"low"`, `"medium"`, `"high"` pass.
  - `" low"`, `"low "`, `"LOW"`, `""` all raise `ValueError`.
- The existing unit test `test_fraud_upd_012_leading_space_risk_level_accepted_without_validation` should now pass.