### PR TITLE
fix: validate flag_reason in flag_invoice_for_review to reject None/empty

### DIFF
--- a/finbot/tools/data/fraud.py
+++ b/finbot/tools/data/fraud.py
@@ -149,6 +149,11 @@ async def flag_invoice_for_review(
     Returns:
         Dictionary containing flagged invoice details
     """
+    if flag_reason is None:
+        raise ValueError("flag_reason must not be None")
+    if not flag_reason.strip():
+        raise ValueError("flag_reason must not be empty or whitespace")
+
     logger.info(
         "Flagging invoice_id: %s for review. Reason: %s, Action: %s",
         invoice_id,


### PR DESCRIPTION
## Summary
Adds input validation to `flag_invoice_for_review` to reject `None` and empty/whitespace-only values for the `flag_reason` parameter.

## Problem
Currently, calling `flag_invoice_for_review(invoice.id, None, ...)` produces a fraud note containing the literal string `"None"` (e.g., `[Fraud Agent] FLAG: None.`). This corrupts structured audit data and makes records unactionable for both human reviewers and automated tooling. The same issue occurs with empty or whitespace-only strings.

## Solution
Insert validation at the top of the function:
- `if flag_reason is None: raise ValueError("flag_reason must not be None")`
- `if not flag_reason.strip(): raise ValueError("flag_reason must not be empty or whitespace")`

The validation runs before any logging or database operations, preventing invalid data from being recorded.

## Impact
- Prevents `None` and empty strings from entering the fraud note.
- Maintains backward compatibility for all valid string inputs.
- Improves data integrity and reliability of fraud records.

## Testing
- Verified that the existing test `test_fraud_flag_013_none_flag_reason_accepted_without_validation` now passes (expects `ValueError`).
- Manually tested with `None`, `""`, `"   "`, and valid strings.
- Ensured no changes to the function’s behavior for valid inputs.