### PR TITLE
Fix: CTF footer alignment and Vendor portal scrolling

### DIFF
--- a/finbot/apps/admin/templates/base.html
+++ b/finbot/apps/admin/templates/base.html
@@ -77,10 +77,10 @@
 
     {% block extra_head %}{% endblock %}
 </head>
-<body class="bg-portal-bg-primary">
+<body class="bg-portal-bg-primary flex flex-col min-h-screen">
     <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 rounded-md z-50 font-medium">Skip to main content</a>
 
-    <div class="flex h-screen relative z-10 overflow-hidden bg-portal-bg-primary">
+    <div class="flex flex-1 min-h-0 relative z-10 overflow-hidden bg-portal-bg-primary">
         <!-- Sidebar -->
         <aside id="sidebar" class="ai-sidebar w-80 flex-shrink-0 flex flex-col overflow-y-auto border-r border-admin-primary/20 bg-portal-bg-secondary/50">
             <!-- Logo -->
@@ -249,7 +249,7 @@
     </div>
 
     <!-- CTF Footer -->
-    {% include 'components/ctf_footer.html' %}
+    <div class="flex-shrink-0">{% include 'components/ctf_footer.html' %}</div>
 
     <script>
         window.CTF_NAMESPACE = "{{ session_context.namespace if session_context else 'default' }}";

--- a/finbot/apps/ctf/templates/base.html
+++ b/finbot/apps/ctf/templates/base.html
@@ -71,9 +71,9 @@
     <!-- Skip to main content for accessibility -->
     <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 quantum-primary px-4 py-2 rounded-md z-50 font-medium">Skip to main content</a>
 
-    <div class="flex h-screen relative z-10">
-        <!-- CTF Sidebar (matching vendor portal style) -->
-        <aside id="sidebar" class="ai-sidebar w-80 flex-shrink-0 flex flex-col border-r border-ctf-primary/20 bg-portal-bg-secondary/50">
+    <div class="flex min-h-screen relative z-10">
+        <!-- CTF Sidebar:(matching vendor portal style)-->
+        <aside id="sidebar" class="ai-sidebar w-80 flex-shrink-0 flex flex-col sticky top-0 h-screen overflow-y-auto border-r border-ctf-primary/20 bg-portal-bg-secondary/50">
             <!-- Logo Section -->
             <div class="sidebar-logo-section p-6 border-b border-ctf-primary/20">
                 <div class="flex items-center space-x-3">
@@ -217,23 +217,22 @@
             <!-- Collapse Toggle -->
             <button class="sidebar-collapse-toggle-bar" onclick="sidebar.toggleCollapse()" title="Collapse sidebar">
                 <svg class="sidebar-collapse-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7"/>
                 </svg>
                 <span class="sidebar-collapsible-text">Collapse</span>
             </button>
         </aside>
 
         <!-- Main Content Area -->
-        <main id="main-content" class="flex-1 flex flex-col overflow-hidden">
-            <!-- Content Area -->
-            <div class="flex-1 overflow-auto p-8">
+        <main id="main-content" class="flex-1">
+            <div class="p-8">
                 {% block content %}{% endblock %}
             </div>
         </main>
     </div>
 
     <!-- CTF Footer -->
-    {% include 'components/ctf_footer.html' %}
+    <div class="relative z-10">{% include 'components/ctf_footer.html' %}</div>
 
     <!-- CTF Context -->
     <script>

--- a/finbot/apps/vendor/templates/base.html
+++ b/finbot/apps/vendor/templates/base.html
@@ -67,9 +67,9 @@
     <!-- Skip to main content for accessibility -->
     <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 quantum-primary px-4 py-2 rounded-md z-50 font-medium">Skip to main content</a>
 
-    <div class="flex h-screen relative z-10 overflow-hidden bg-portal-bg-primary">
+    <div class="flex min-h-screen relative z-10 bg-portal-bg-primary">
         <!-- Sidebar -->
-        <aside id="sidebar" class="ai-sidebar w-80 flex-shrink-0 flex flex-col overflow-y-auto">
+        <aside id="sidebar" class="ai-sidebar w-80 flex-shrink-0 flex flex-col sticky top-0 h-screen overflow-y-auto">
             <!-- Logo Section -->
             <div class="sidebar-logo-section p-6 border-b border-vendor-primary/20">
                 <div class="flex items-center space-x-3">
@@ -261,9 +261,9 @@
         </aside>
 
         <!-- Main Content Area -->
-        <main id="main-content" class="flex-1 flex flex-col overflow-hidden">
+        <main id="main-content" class="flex-1 flex flex-col">
             <!-- Top Header -->
-            <header class="bg-portal-bg-secondary/80 backdrop-blur-md border-b border-vendor-primary/20 px-6 py-4">
+            <header class="bg-portal-bg-secondary/80 backdrop-blur-md border-b border-vendor-primary/20 px-6 py-4 sticky top-0 z-10">
                 <div class="flex items-center justify-between">
                     <div>
                         <h1 id="page-title" class="text-2xl font-bold text-text-bright">{% block page_title %}Dashboard{% endblock %}</h1>
@@ -289,14 +289,14 @@
             </header>
 
             <!-- Content Area -->
-            <div class="flex-1 overflow-auto p-6">
+            <div class="flex-1 p-6">
                 {% block content %}{% endblock %}
             </div>
         </main>
     </div>
 
     <!-- CTF Footer -->
-    {% include 'components/ctf_footer.html' %}
+    <div class="relative z-10">{% include 'components/ctf_footer.html' %}</div>
 
     <!-- CTF Sidecar Panel -->
     {% include 'components/ctf_sidecar.html' %}


### PR DESCRIPTION
close #215 

**Changes**

**CTF portal** — Moved footer outside the flex wrapper so it spans full width (sidebar + content) and appears at the bottom when scrolled to
<img width="1905" height="459" alt="image" src="https://github.com/user-attachments/assets/489a6886-f646-4039-9b25-3c24c01cff59" />

**Vendor portal** — Removed overflow-hidden / h-screen lock; sidebar made sticky so page scrolls naturally while sidebar stays in view
<img width="1510" height="867" alt="image" src="https://github.com/user-attachments/assets/feafcaf3-1361-457f-bb0e-39cb6420d681" />
