### PR TITLE
fix(fraud): validate recommended_action in flag_invoice_for_review

### DIFF
--- a/finbot/tools/data/fraud.py
+++ b/finbot/tools/data/fraud.py
@@ -161,6 +161,12 @@ async def flag_invoice_for_review(
         if not invoice:
             raise ValueError("Invoice not found")
 
+          # --- NEW VALIDATION ---
+        VALID_ACTIONS = {"hold", "reject", "escalate", "monitor"}
+        if recommended_action not in VALID_ACTIONS:
+            raise ValueError(f"Invalid recommended_action: {recommended_action!r}. Must be one of {VALID_ACTIONS}")
+        # --- END NEW VALIDATION ---
+
         previous_state = {
             "status": invoice.status,
         }


### PR DESCRIPTION
## Summary
Prevents `flag_invoice_for_review` from accepting invalid `recommended_action` strings (e.g., `" hold"`, `"HOLD"`) by adding explicit validation against a set of allowed actions.

## Problem
The function currently accepts any string for `recommended_action`. Values with leading/trailing spaces (like `" hold"`) bypass the only action‑specific check (`recommended_action == "reject"`) and are stored unchanged in the database. This violates the documented contract and could cause silent data corruption or future logic failures.

## Root Cause
There is no input validation for `recommended_action`. The function relies solely on an exact‑match check for `"reject"`, which fails for any variant with extra whitespace. Any other action value (including malformed ones) is accepted without verification.

## Solution
Insert a validation block immediately after confirming the invoice exists:

```python
VALID_ACTIONS = {"hold", "reject", "escalate", "monitor"}
if recommended_action not in VALID_ACTIONS:
    raise ValueError(f"Invalid recommended_action: {recommended_action!r}. Must be one of {VALID_ACTIONS}")