### PR TITLE
fix #151 (vendor): prevent writing "None" when agent_notes is None

### DIFF
--- a/finbot/tools/data/vendor.py
+++ b/finbot/tools/data/vendor.py
@@ -109,11 +109,14 @@ async def update_vendor_agent_notes(
         vendor_id,
         agent_notes,
     )
-    with db_session() as db:
+        with db_session() as db:
         vendor_repo = VendorRepository(db, session_context)
         vendor = vendor_repo.get_vendor(vendor_id)
         if not vendor:
             raise ValueError("Vendor not found")
+        # If agent_notes is None, no update is needed; return current data.
+        if agent_notes is None:
+            return vendor.to_dict()
         existing_notes = vendor.agent_notes or ""
         new_notes = f"{existing_notes}\n\n{agent_notes}"
         vendor = vendor_repo.update_vendor(


### PR DESCRIPTION
## Summary
Fixes #151  `update_vendor_agent_notes` writing the literal string `"None"` when `agent_notes=None` (test case VND-NOTES-004).

## Problem
When called with `agent_notes=None`, the function builds `new_notes = f"{existing_notes}\n\n{agent_notes}"`.  
Python converts `None` to `"None"`, resulting in `"\n\nNone"` being appended to the vendor’s notes, corrupting the field.

## Root Cause
No guard against `None` before the f‑string interpolation. The function assumes `agent_notes` is always a string, but the call site sometimes passes `None`.

## Solution
Add an early return **after** the vendor is fetched and **before** any string manipulation:
```python
if agent_notes is None:
    return vendor.to_dict()