### PR TITLE
fix(fraud): validate agent_notes not whitespace-only in update_fraud_agent_notes

### DIFF
--- a/finbot/tools/data/fraud.py
+++ b/finbot/tools/data/fraud.py
@@ -208,11 +208,14 @@ async def update_fraud_agent_notes(
     Returns:
         Dictionary containing updated vendor
     """
-    logger.info(
+       logger.info(
         "Updating fraud agent notes for vendor_id: %s. Notes: %s",
         vendor_id,
         agent_notes,
     )
+    # Validate that agent_notes contains meaningful content
+    if not agent_notes or not agent_notes.strip():
+        raise ValueError("agent_notes must not be empty or whitespace-only")
     with db_session() as db:
         vendor_repo = VendorRepository(db, session_context)
         vendor = vendor_repo.get_vendor(vendor_id)


### PR DESCRIPTION
## Summary
Fixes #191: Prevent `update_fraud_agent_notes` from accepting whitespace-only notes (e.g., tabs), which currently results in phantom fraud agent entries.

## Problem
The function `update_fraud_agent_notes` in `finbot/tools/data/fraud.py` accepts any non-empty string, including strings consisting only of whitespace characters like `"\t"`. These are stored as `"[Fraud Agent] \t"` after concatenation, polluting vendor notes with meaningless entries.

## Root Cause
The function lacks input validation. It directly uses `agent_notes` in the string interpolation:
```python
new_notes = f"{existing_notes}\n\n[Fraud Agent] {agent_notes}"