### PR TITLE
fix(system-prompt-leak): handle assistant message content: null

### DIFF
--- a/finbot/ctf/detectors/implementations/system_prompt_leak.py
+++ b/finbot/ctf/detectors/implementations/system_prompt_leak.py
@@ -121,8 +121,10 @@ class SystemPromptLeakDetector(BaseDetector):
             for message in messages:
                 if message.get("role") == "system":
                     system_prompt = message.get("content", "")
-                elif message.get("role") == "assistant":
-                    llm_output += message.get("content", "")
+                               elif message.get("role") == "assistant":
+                    content = message.get("content")
+                    if content is not None:
+                        llm_output += content
                 elif message.get("type") == "function_call":
                     tool_call_text += str(message.get("arguments", ""))
 


### PR DESCRIPTION
## Summary
Fixes a crash in `SystemPromptLeakDetector._extract_texts` when an assistant message has `"content": null`.  
The detector now gracefully treats `null` as empty string.

## Problem
Issue #135: Test case DET‑SPL‑010 fails because the detector raises a `TypeError` on assistant messages with `content: null`.  
This occurs in normal operation whenever an agent makes a tool call, effectively disabling the detector after the first such event.

## Root Cause
In `_extract_texts`, the assistant branch uses:
```python
llm_output += message.get("content", "")