### PR TITLE
fix(fraud): validate recommended_action to prevent None being accepted

### DIFF
--- a/finbot/tools/data/fraud.py
+++ b/finbot/tools/data/fraud.py
@@ -142,7 +142,7 @@ async def flag_invoice_for_review(
     Args:
         invoice_id: The ID of the invoice to flag
         flag_reason: Reason for flagging (e.g., 'suspicious_amount', 'duplicate', 'vendor_risk')
-        recommended_action: Recommended action ('hold', 'reject', 'escalate')
+        recommended_action: Recommended action ('hold', 'reject', 'escalate', 'monitor')
         agent_notes: Detailed fraud assessment notes
         session_context: The session context
 
@@ -155,6 +155,15 @@ async def flag_invoice_for_review(
         flag_reason,
         recommended_action,
     )
+
+    # Validate recommended_action
+    VALID_ACTIONS = {"hold", "reject", "escalate", "monitor"}
+    if recommended_action not in VALID_ACTIONS:
+        raise ValueError(
+            f"Invalid recommended_action: {recommended_action!r}. "
+            f"Must be one of {VALID_ACTIONS}"
+        )
+
     with db_session() as db:
         invoice_repo = InvoiceRepository(db, session_context)
         invoice = invoice_repo.get_invoice(invoice_id)


### PR DESCRIPTION
## Summary
Fixes #188 by adding input validation to `flag_invoice_for_review` so that `None` (and any other invalid value) raises a `ValueError` instead of being silently stored as the string `"None"`.

## Problem
When `recommended_action=None` is passed, the function:
- Stores `"Recommended action: None."` in the fraud note.
- Never triggers the status change for `"reject"` because `None != "reject"`.
- Leaves the invoice in its original state with a misleading note.

## Root Cause
The function lacks any validation of the `recommended_action` parameter. It is used directly in string formatting and a conditional without being checked against a whitelist of allowed actions.

## Solution
1. Define a set `VALID_ACTIONS = {"hold", "reject", "escalate", "monitor"}`.
2. Immediately after logging, check `if recommended_action not in VALID_ACTIONS` and raise a descriptive `ValueError` if the check fails.
3. Update the docstring to include `'monitor'` in the list of accepted actions (it was already implied as valid by the issue's acceptance criteria).

## Impact
- **No breaking changes**  :  all existing calls with valid actions (`"hold"`, `"reject"`, `"escalate"`) work exactly as before.
- **Minimal diff** : only a few lines added; no refactoring or unrelated changes.
- **Improved correctness** :  invalid inputs are now rejected early, preventing silent data corruption.

## Testing
- Manually tested with `recommended_action=None` → `ValueError`.
- Verified that `"hold"`, `"reject"`, `"escalate"`, and `"monitor"` are accepted.
- Confirmed that `"reject"` still changes the invoice status when appropriate.