### PR TITLE
Fix(invoice): reject trailing spaces and invalid status values in update_invoice_status

### DIFF
--- a/finbot/tools/data/invoice.py
+++ b/finbot/tools/data/invoice.py
@@ -9,6 +9,9 @@ from finbot.core.data.repositories import InvoiceRepository
 
 logger = logging.getLogger(__name__)
 
+# Valid invoice statuses – must exactly match one of these values
+VALID_INVOICE_STATUSES = {"submitted", "processing", "approved", "rejected", "paid"}
+
 
 async def get_invoice_details(
     invoice_id: int, session_context: SessionContext
@@ -57,8 +60,15 @@ async def update_invoice_status(
         previous_state = {
             "status": invoice.status,
         }
-        existing_notes = invoice.agent_notes or ""
+            existing_notes = invoice.agent_notes or ""
         new_notes = f"{existing_notes}\n\n{agent_notes}"
+
+        # Validate status
+        if status not in VALID_INVOICE_STATUSES:
+            raise ValueError(
+                f"Invalid status '{status}'. Must be one of: {sorted(VALID_INVOICE_STATUSES)}"
+            )
+
         invoice = invoice_repo.update_invoice(
             invoice_id, status=status, agent_notes=new_notes
         )


### PR DESCRIPTION
## Summary
Fixes #179 – `update_invoice_status` now rejects status strings with trailing spaces (or any value not in the allowed set).

## Problem
The function `update_invoice_status` accepts any string as the `status` argument and stores it directly in the database. This allows inputs like `"approved "` (with a trailing space) to be persisted, which then break all exact‑match comparisons (e.g., `status == "approved"`). The issue was discovered by test `test_inv_upd_011`.

## Root Cause
No validation of the `status` argument against the domain‑allowed statuses. The code directly passed the user‑supplied string to the repository update call.

## Solution
1. Added a module‑level constant `VALID_INVOICE_STATUSES` containing the exact allowed status strings.
2. Inserted a membership check before the repository update; if the status is not in the set, a `ValueError` is raised with a descriptive message.

### Code Changes
**File:** `finbot/tools/data/invoice.py`

**1. Define valid statuses** (inserted after logger definition):
```python
# Valid invoice statuses – must exactly match one of these values
VALID_INVOICE_STATUSES = {"submitted", "processing", "approved", "rejected", "paid"}