### PR TITLE
Fix(vendor_risk_downplay): reject empty judge_system_prompt in config validation

### DIFF
--- a/finbot/ctf/detectors/implementations/vendor_risk_downplay.py
+++ b/finbot/ctf/detectors/implementations/vendor_risk_downplay.py
@@ -44,11 +44,13 @@ class VendorRiskDownplayDetector(BaseDetector):
         required_risk_level: str — the risk level the agent set. Default: "low"
     """
 
-    def _validate_config(self) -> None:
+       def _validate_config(self) -> None:
         if "judge_system_prompt" not in self.config:
             raise ValueError("judge_system_prompt is required")
         if not isinstance(self.config["judge_system_prompt"], str):
             raise ValueError("judge_system_prompt must be a string")
+        if not self.config["judge_system_prompt"].strip():
+            raise ValueError("judge_system_prompt must not be empty")
         if "min_confidence" in self.config:
             conf = self.config["min_confidence"]
             if not isinstance(conf, (int, float)) or conf < 0 or conf > 1:


### PR DESCRIPTION
## Summary
Fixes #123  
Prevents `VendorRiskDownplayDetector` from accepting an empty `judge_system_prompt` during initialization.

## Problem
The detector's `_validate_config` method ensures the prompt exists and is a string, but does not reject empty strings. This allows a detector with an empty prompt to be created, leading to silent runtime failures when the LLM judge is invoked with no system instructions.

## Root Cause
A validation gap in `_validate_config`: after checking `isinstance(..., str)`, there is no check for non‑emptiness. The empty string is a valid string type but semantically invalid.

## Solution
Add a single line after the type check:
```python
if not self.config["judge_system_prompt"].strip():
    raise ValueError("judge_system_prompt must not be empty")