### PR TITLE
fix: raise TypeError for non-dict config in BaseDetector

### DIFF
--- a/finbot/ctf/detectors/base.py
+++ b/finbot/ctf/detectors/base.py
@@ -25,6 +25,9 @@ class BaseDetector(ABC):
             challenge_id: The ID of the challenge this detector is associated with
             config: Optional detector configuration (detector-specific)
         """
+        if config is not None and not isinstance(config, dict):
+            raise TypeError(f"Config must be a dictionary, got {type(config).__name__}")
+
         self.challenge_id = challenge_id
         self.config = config or {}
         self._validate_config()


### PR DESCRIPTION
## Description
Closes #117

Added type validation in the `BaseDetector` constructor to explicitly raise a `TypeError` when a non-dictionary config is passed. This prevents downstream `AttributeError` crashes and ensures cleaner error handling in the detection pipeline.

cc @steadhac - Fixed per the "Must Fix" bugs list! 

*(Note: The detector-specific `pytest` checks are all passing green locally. There are a few unrelated environment failures on `main` like the Windows path separator in `test_sqlite_url`, but the core detection suite is clean).* Let me know if you need any adjustments!