### PR TITLE
fix: add input validation for agent_notes length and whitespace in fraud, vendor, and invoice tools

### DIFF
--- a/finbot/tools/data/fraud.py
+++ b/finbot/tools/data/fraud.py
@@ -166,6 +166,8 @@ async def flag_invoice_for_review(
         }
 
         existing_notes = invoice.agent_notes or ""
+        if len(flag_reason) > 10_000:
+            raise ValueError("flag_reason must not exceed 10,000 characters")
         fraud_note = (
             f"[Fraud Agent] FLAG: {flag_reason}. "
             f"Recommended action: {recommended_action}. "
@@ -218,6 +220,10 @@ async def update_fraud_agent_notes(
         vendor = vendor_repo.get_vendor(vendor_id)
         if not vendor:
             raise ValueError("Vendor not found")
+        
+        if agent_notes and len(agent_notes) > 10_000:
+            raise ValueError("agent_notes exceeds maximum length of 10,000 characters")
+
         existing_notes = vendor.agent_notes or ""
         new_notes = f"{existing_notes}\n\n[Fraud Agent] {agent_notes}"
         vendor = vendor_repo.update_vendor(

--- a/finbot/tools/data/invoice.py
+++ b/finbot/tools/data/invoice.py
@@ -57,6 +57,7 @@ async def update_invoice_status(
         previous_state = {
             "status": invoice.status,
         }
+
         existing_notes = invoice.agent_notes or ""
         new_notes = f"{existing_notes}\n\n{agent_notes}"
         invoice = invoice_repo.update_invoice(
@@ -87,6 +88,8 @@ async def update_invoice_agent_notes(
         invoice = invoice_repo.get_invoice(invoice_id)
         if not invoice:
             raise ValueError("Invoice not found")
+        if agent_notes and len(agent_notes) > 10_000:
+            raise ValueError("agent_notes exceeds maximum length of 10,000 characters")
         existing_notes = invoice.agent_notes or ""
         new_notes = f"{existing_notes}\n\n{agent_notes}"
         invoice = invoice_repo.update_invoice(
@@ -96,3 +99,4 @@ async def update_invoice_agent_notes(
         if not invoice:
             raise ValueError("Invoice not found")
         return invoice.to_dict()
+    

--- a/finbot/tools/data/vendor.py
+++ b/finbot/tools/data/vendor.py
@@ -114,6 +114,9 @@ async def update_vendor_agent_notes(
         vendor = vendor_repo.get_vendor(vendor_id)
         if not vendor:
             raise ValueError("Vendor not found")
+        
+        if not agent_notes or not agent_notes.strip():
+            raise ValueError("agent_notes must not be empty or whitespace-only")
         existing_notes = vendor.agent_notes or ""
         new_notes = f"{existing_notes}\n\n{agent_notes}"
         vendor = vendor_repo.update_vendor(


### PR DESCRIPTION
## Summary

Fixes four input validation bugs across fraud.py, vendor.py, and invoice.py.

## Changes

**fraud.py**
- `update_fraud_agent_notes`: raises ValueError when agent_notes exceeds 10,000 characters (Bug #056)
- `flag_invoice_for_review`: raises ValueError when flag_reason exceeds 10,000 characters (Bug #075)

**vendor.py**
- `update_vendor_agent_notes`: raises ValueError when agent_notes is empty or whitespace-only (Bug #053)

**invoice.py**
- `update_invoice_agent_notes`: raises ValueError when agent_notes exceeds 10,000 characters (Bug #052)

## Issues Fixed

Closes #167
Closes #186
Closes #164
Closes #163

## Why this matters

Unbounded inputs allow context window stuffing attacks that degrade audit log 
readability and LLM processing. Whitespace-only notes silently pollute the 
audit trail making it appear active when it contains no information.