### PR TITLE
fix(ci): conftest client fixture crashes — load_definitions_on_startup removed from finbot.main

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -42,7 +42,7 @@ def client():
     tasks during test teardown.
     """
     with patch("finbot.main.start_processor_task", return_value=None), \
-         patch("finbot.main.load_definitions_on_startup", return_value={"challenges": [], "badges": []}):
+         patch("finbot.main.load_definitions_on_startup", return_value={"challenges": [], "badges": []}, create=True):
         with TestClient(app) as test_client:
             yield test_client
 


### PR DESCRIPTION
## Summary
- `fab2184` removed the module-level import of `load_definitions_on_startup` from `finbot/main.py`
- All feature branches still patch `finbot.main.load_definitions_on_startup` in the `client` fixture, causing `AttributeError` on CI for every test that uses it
- Add `create=True` so the patch works whether or not the attribute exists in `finbot.main`

## Fix
One word added to `tests/unit/conftest.py` line 45: `create=True`

## Test plan
- [ ] CI passes on `tests/unit/vendor/test_vendor_isolation.py` (was 12 errors)
- [ ] All other unit tests continue to pass

Fixes: Bug_109