### PR TITLE
fix: handle None invoice_date and due_date in Invoice.to_dict()

### DIFF
--- a/finbot/core/data/models.py
+++ b/finbot/core/data/models.py
@@ -404,8 +404,12 @@ class Invoice(Base):
             "invoice_number": self.invoice_number,
             "amount": self.amount,
             "description": self.description,
-            "invoice_date": self.invoice_date.isoformat().replace("+00:00", "Z"),
-            "due_date": self.due_date.isoformat().replace("+00:00", "Z"),
+            "invoice_date": self.invoice_date.isoformat().replace("+00:00", "Z")
+            if self.invoice_date
+            else None,
+            "due_date": self.due_date.isoformat().replace("+00:00", "Z")
+            if self.due_date
+            else None,
             "status": self.status,
             "agent_notes": self.agent_notes,
             "attachments": attachments,

--- a/tests/unit/database/test_invoice_none_dates.py
+++ b/tests/unit/database/test_invoice_none_dates.py
@@ -1,0 +1,64 @@
+"""Tests for Invoice.to_dict() handling None date fields.
+
+Covers:
+- Issue #290: get_invoice_for_payment crashes when invoice_date is None
+- Issue #291: get_invoice_for_payment crashes when due_date is None
+"""
+
+from datetime import datetime, timezone
+
+from finbot.core.data.models import Invoice
+
+NOW = datetime(2026, 3, 23, tzinfo=timezone.utc)
+
+
+def _make_invoice(**overrides):
+    """Create an Invoice with sensible defaults for testing."""
+    defaults = {
+        "id": 1,
+        "namespace": "test",
+        "vendor_id": 1,
+        "amount": 100.0,
+        "invoice_date": NOW,
+        "due_date": NOW,
+        "status": "submitted",
+        "created_at": NOW,
+        "updated_at": NOW,
+    }
+    defaults.update(overrides)
+    return Invoice(**defaults)
+
+
+def test_invoice_to_dict_with_none_invoice_date():
+    """PAY-FIELD-001: to_dict should not crash when invoice_date is None."""
+    invoice = _make_invoice(invoice_date=None)
+    result = invoice.to_dict()
+    assert result["invoice_date"] is None
+    assert result["due_date"] is not None
+
+
+def test_invoice_to_dict_with_none_due_date():
+    """PAY-FIELD-002: to_dict should not crash when due_date is None."""
+    invoice = _make_invoice(due_date=None)
+    result = invoice.to_dict()
+    assert result["due_date"] is None
+    assert result["invoice_date"] is not None
+
+
+def test_invoice_to_dict_with_both_dates_none():
+    """to_dict should handle both invoice_date and due_date being None."""
+    invoice = _make_invoice(invoice_date=None, due_date=None)
+    result = invoice.to_dict()
+    assert result["invoice_date"] is None
+    assert result["due_date"] is None
+
+
+def test_invoice_to_dict_with_valid_dates():
+    """to_dict should still work correctly with valid dates."""
+    invoice = _make_invoice(
+        invoice_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        due_date=datetime(2026, 2, 1, tzinfo=timezone.utc),
+    )
+    result = invoice.to_dict()
+    assert result["invoice_date"] == "2026-01-01T00:00:00Z"
+    assert result["due_date"] == "2026-02-01T00:00:00Z"


### PR DESCRIPTION
## Summary
- Add None guards for `invoice_date` and `due_date` in `Invoice.to_dict()` to prevent `AttributeError` crash when either field is `None`
- Follows the same pattern already used in `get_vendor_payment_summary`
- Add unit tests covering None date scenarios

Fixes #290, Fixes #291

## Test plan
- [x] `test_invoice_to_dict_with_none_invoice_date` — verifies no crash when `invoice_date` is None (PAY-FIELD-001)
- [x] `test_invoice_to_dict_with_none_due_date` — verifies no crash when `due_date` is None (PAY-FIELD-002)
- [x] `test_invoice_to_dict_with_both_dates_none` — edge case with both None
- [x] `test_invoice_to_dict_with_valid_dates` — regression test for normal behavior