### PR TITLE
fix: validate payment inputs in process_payment and update_payment_agent_notes

### DIFF
--- a/finbot/tools/data/payment.py
+++ b/finbot/tools/data/payment.py
@@ -63,6 +63,11 @@ async def process_payment(
     Returns:
         Dictionary containing payment result
     """
+    if not payment_method or not isinstance(payment_method, str) or not payment_method.strip():
+        raise ValueError("payment_method is required and cannot be empty")
+    if payment_reference is None:
+        raise ValueError("payment_reference is required")
+
     logger.info(
         "Processing payment for invoice_id: %s, method: %s, ref: %s",
         invoice_id,
@@ -175,6 +180,9 @@ async def update_payment_agent_notes(
     Returns:
         Dictionary containing updated invoice
     """
+    if agent_notes is None:
+        raise ValueError("agent_notes is required and cannot be None")
+
     logger.info(
         "Updating payment agent notes for invoice_id: %s. Agent notes: %s",
         invoice_id,

--- a/tests/unit/database/test_payment_validation.py
+++ b/tests/unit/database/test_payment_validation.py
@@ -1,0 +1,77 @@
+"""Tests for payment input validation.
+
+Covers:
+- Issue #286: process_payment accepts empty string payment_method
+- Issue #287: process_payment accepts payment_method=None
+- Issue #288: update_payment_agent_notes accepts agent_notes=None
+"""
+
+import pytest
+
+from finbot.tools.data.payment import process_payment, update_payment_agent_notes
+
+
+class TestProcessPaymentValidation:
+    """Validation tests for process_payment."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_none_payment_method(self):
+        """PAY-PROC-007: payment_method=None should raise ValueError."""
+        with pytest.raises(ValueError, match="payment_method is required"):
+            await process_payment(
+                invoice_id=1,
+                payment_method=None,
+                payment_reference="REF-001",
+                agent_notes="test",
+                session_context=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_payment_method(self):
+        """PAY-PROC-008: empty string payment_method should raise ValueError."""
+        with pytest.raises(ValueError, match="payment_method is required"):
+            await process_payment(
+                invoice_id=1,
+                payment_method="",
+                payment_reference="REF-001",
+                agent_notes="test",
+                session_context=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_whitespace_payment_method(self):
+        """Whitespace-only payment_method should raise ValueError."""
+        with pytest.raises(ValueError, match="payment_method is required"):
+            await process_payment(
+                invoice_id=1,
+                payment_method="   ",
+                payment_reference="REF-001",
+                agent_notes="test",
+                session_context=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_none_payment_reference(self):
+        """PAY-PROC-009: payment_reference=None should raise ValueError."""
+        with pytest.raises(ValueError, match="payment_reference is required"):
+            await process_payment(
+                invoice_id=1,
+                payment_method="bank_transfer",
+                payment_reference=None,
+                agent_notes="test",
+                session_context=None,
+            )
+
+
+class TestUpdatePaymentAgentNotesValidation:
+    """Validation tests for update_payment_agent_notes."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_none_agent_notes(self):
+        """PAY-NOTES-005: agent_notes=None should raise ValueError."""
+        with pytest.raises(ValueError, match="agent_notes is required"):
+            await update_payment_agent_notes(
+                invoice_id=1,
+                agent_notes=None,
+                session_context=None,
+            )


### PR DESCRIPTION
## Summary
- Reject `None` and empty string `payment_method` in `process_payment` to prevent writing invalid data to invoices
- Reject `None` `payment_reference` in `process_payment` to prevent literal "None" in invoice notes
- Reject `None` `agent_notes` in `update_payment_agent_notes` to prevent appending "[Payments Agent] None"

Fixes #285, Fixes #286, Fixes #287, Fixes #288

## Test plan
- [x] `test_rejects_none_payment_method` — PAY-PROC-007 (#285, #287)
- [x] `test_rejects_empty_payment_method` — PAY-PROC-008 (#286)
- [x] `test_rejects_whitespace_payment_method` — whitespace edge case
- [x] `test_rejects_none_payment_reference` — PAY-PROC-009 (#287)
- [x] `test_rejects_none_agent_notes` — PAY-NOTES-005 (#288)