### PR TITLE
fix: enforce SESSION_COOKIE_SECURE in production mode

### DIFF
--- a/finbot/config.py
+++ b/finbot/config.py
@@ -143,6 +143,11 @@ class Settings(BaseSettings):
             self.DATABASE_TYPE = self._detect_database_type()  # pylint: disable=C0103
         if not self.SESSION_SIGNING_KEY:
             self.SESSION_SIGNING_KEY = self._derive_session_signing_key()  # pylint: disable=C0103
+        if not self.DEBUG and not self.SESSION_COOKIE_SECURE:
+            raise ValueError(
+                "SESSION_COOKIE_SECURE must be True in production (DEBUG=False). "
+                "Set SESSION_COOKIE_SECURE=True or use DEBUG=True for local development."
+            )
         return self
 
     def _derive_session_signing_key(self) -> str:

--- a/tests/unit/auth/test_session_cookie_secure.py
+++ b/tests/unit/auth/test_session_cookie_secure.py
@@ -1,0 +1,47 @@
+"""Tests for SESSION_COOKIE_SECURE enforcement.
+
+Covers:
+- Issue #202: Session cookies sent over HTTP by default
+"""
+
+import pytest
+
+from finbot.config import Settings
+
+
+def test_production_rejects_insecure_cookies():
+    """Production mode (DEBUG=False) must reject SESSION_COOKIE_SECURE=False."""
+    with pytest.raises(ValueError, match="SESSION_COOKIE_SECURE must be True"):
+        Settings(
+            DEBUG=False,
+            SESSION_COOKIE_SECURE=False,
+            SECRET_KEY="a-real-production-secret-key-that-is-not-default",
+        )
+
+
+def test_production_accepts_secure_cookies():
+    """Production mode (DEBUG=False) with SESSION_COOKIE_SECURE=True should work."""
+    s = Settings(
+        DEBUG=False,
+        SESSION_COOKIE_SECURE=True,
+        SECRET_KEY="a-real-production-secret-key-that-is-not-default",
+    )
+    assert s.SESSION_COOKIE_SECURE is True
+
+
+def test_dev_mode_allows_insecure_cookies():
+    """Development mode (DEBUG=True) can use insecure cookies for local testing."""
+    s = Settings(
+        DEBUG=True,
+        SESSION_COOKIE_SECURE=False,
+    )
+    assert s.SESSION_COOKIE_SECURE is False
+
+
+def test_dev_mode_allows_secure_cookies():
+    """Development mode (DEBUG=True) with secure cookies should also work."""
+    s = Settings(
+        DEBUG=True,
+        SESSION_COOKIE_SECURE=True,
+    )
+    assert s.SESSION_COOKIE_SECURE is True


### PR DESCRIPTION
## Summary
- Add validation in `Settings.validate_model()` to reject `SESSION_COOKIE_SECURE=False` when `DEBUG=False`
- Production deployments without HTTPS-only cookies now fail at startup with a clear error message
- Development mode (`DEBUG=True`) can still use insecure cookies for local testing

Fixes #202

## Test plan
- [x] `test_production_rejects_insecure_cookies` — verifies startup fails with insecure cookies in production
- [x] `test_production_accepts_secure_cookies` — verifies production works with secure cookies
- [x] `test_dev_mode_allows_insecure_cookies` — verifies dev mode allows insecure cookies
- [x] `test_dev_mode_allows_secure_cookies` — verifies dev mode works with secure cookies too