### PR TITLE
fix: extract CSRF token from form submissions

### DIFF
--- a/finbot/core/auth/csrf.py
+++ b/finbot/core/auth/csrf.py
@@ -61,7 +61,7 @@ class CSRFProtectionMiddleware(BaseHTTPMiddleware):
 
         # Validate CSRF token
         try:
-            self._validate_csrf_token(request)
+            await self._validate_csrf_token(request)
         except HTTPException as e:
             logger.warning(
                 "CSRF validation failed for %s %s from %s: %s",
@@ -81,7 +81,7 @@ class CSRFProtectionMiddleware(BaseHTTPMiddleware):
         """Check if path is exempt from CSRF protection"""
         return any(path.startswith(exempt) for exempt in self.EXEMPT_PATHS)
 
-    def _validate_csrf_token(self, request: Request) -> None:
+    async def _validate_csrf_token(self, request: Request) -> None:
         """Validate CSRF token from request"""
 
         # Get session context (should be set by SessionMiddleware)
@@ -99,7 +99,7 @@ class CSRFProtectionMiddleware(BaseHTTPMiddleware):
             raise HTTPException(status_code=403, detail="No CSRF token in session")
 
         # Get CSRF token from request
-        request_token = self._extract_csrf_token(request)
+        request_token = await self._extract_csrf_token(request)
         if not request_token:
             raise HTTPException(
                 status_code=403, detail="CSRF token missing from request"
@@ -113,7 +113,7 @@ class CSRFProtectionMiddleware(BaseHTTPMiddleware):
             "CSRF validation successful for %s %s", request.method, request.url.path
         )
 
-    def _extract_csrf_token(self, request: Request) -> str | None:
+    async def _extract_csrf_token(self, request: Request) -> str | None:
         """Extract CSRF token from request headers or form data"""
 
         # Try header first (for AJAX requests)
@@ -122,19 +122,15 @@ class CSRFProtectionMiddleware(BaseHTTPMiddleware):
             return token
 
         # Try form data (for regular form submissions)
-        # Note: Form parsing in middleware is complex, so we primarily rely on header-based CSRF
-        # Form-based CSRF tokens are handled by JavaScript submission or custom form parsing
-
-        # For content-type application/x-www-form-urlencoded or multipart/form-data
         content_type = request.headers.get("content-type", "").lower()
         if (
             "application/x-www-form-urlencoded" in content_type
             or "multipart/form-data" in content_type
         ):
-            # We'll need to parse form data, but this is tricky in middleware
-            # For now, rely on header-based CSRF for API endpoints
-            # Form-based CSRF will be handled by template injection
-            pass
+            form = await request.form()
+            token = form.get(settings.CSRF_TOKEN_NAME)
+            if token:
+                return token
 
         return None
 

--- a/tests/unit/auth/test_csrf_form_extraction.py
+++ b/tests/unit/auth/test_csrf_form_extraction.py
@@ -1,0 +1,85 @@
+"""Tests for CSRF token extraction from form submissions.
+
+Covers:
+- Issue #200: CSRF protection silently skipped for form submissions
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from finbot.core.auth.csrf import CSRFProtectionMiddleware
+from finbot.config import settings
+
+
+@pytest.fixture
+def csrf_middleware():
+    app = MagicMock()
+    return CSRFProtectionMiddleware(app)
+
+
+def _make_request(headers=None, form_data=None):
+    """Create a mock request with given headers and form data."""
+    request = MagicMock()
+    request.headers = headers or {}
+
+    async def mock_form():
+        return form_data or {}
+
+    request.form = mock_form
+    return request
+
+
+class TestExtractCsrfToken:
+    """Tests for _extract_csrf_token."""
+
+    @pytest.mark.asyncio
+    async def test_extracts_token_from_header(self, csrf_middleware):
+        """Header-based CSRF should still work."""
+        request = _make_request(
+            headers={settings.CSRF_HEADER_NAME: "test-token-123"}
+        )
+        token = await csrf_middleware._extract_csrf_token(request)
+        assert token == "test-token-123"
+
+    @pytest.mark.asyncio
+    async def test_extracts_token_from_form_urlencoded(self, csrf_middleware):
+        """Form submissions should extract CSRF token from form body."""
+        request = _make_request(
+            headers={"content-type": "application/x-www-form-urlencoded"},
+            form_data={settings.CSRF_TOKEN_NAME: "form-token-456"},
+        )
+        token = await csrf_middleware._extract_csrf_token(request)
+        assert token == "form-token-456"
+
+    @pytest.mark.asyncio
+    async def test_extracts_token_from_multipart_form(self, csrf_middleware):
+        """Multipart form submissions should extract CSRF token."""
+        request = _make_request(
+            headers={"content-type": "multipart/form-data; boundary=---"},
+            form_data={settings.CSRF_TOKEN_NAME: "multipart-token-789"},
+        )
+        token = await csrf_middleware._extract_csrf_token(request)
+        assert token == "multipart-token-789"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_token_in_form(self, csrf_middleware):
+        """Form without CSRF token should return None."""
+        request = _make_request(
+            headers={"content-type": "application/x-www-form-urlencoded"},
+            form_data={"other_field": "value"},
+        )
+        token = await csrf_middleware._extract_csrf_token(request)
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_header_takes_priority_over_form(self, csrf_middleware):
+        """Header token should be returned even if form also has a token."""
+        request = _make_request(
+            headers={
+                settings.CSRF_HEADER_NAME: "header-token",
+                "content-type": "application/x-www-form-urlencoded",
+            },
+            form_data={settings.CSRF_TOKEN_NAME: "form-token"},
+        )
+        token = await csrf_middleware._extract_csrf_token(request)
+        assert token == "header-token"


### PR DESCRIPTION
## Summary
- Parse CSRF token from form body (`request.form()`) for `application/x-www-form-urlencoded` and `multipart/form-data` requests
- Previously, the `_extract_csrf_token` method had a `pass` block for form content types, silently bypassing CSRF validation
- Made `_validate_csrf_token` and `_extract_csrf_token` async to support `await request.form()`
- Header-based CSRF continues to work and takes priority over form tokens

Fixes #200

## Test plan
- [x] `test_extracts_token_from_header` — existing header-based CSRF still works
- [x] `test_extracts_token_from_form_urlencoded` — form body token extraction works
- [x] `test_extracts_token_from_multipart_form` — multipart form token extraction works
- [x] `test_returns_none_when_no_token_in_form` — missing token returns None (triggers 403)
- [x] `test_header_takes_priority_over_form` — header token takes precedence