### PR TITLE
fix: add timeout to agent tool calls to prevent indefinite blocking

### DIFF
--- a/finbot/agents/base.py
+++ b/finbot/agents/base.py
@@ -1,5 +1,6 @@
 """Base Agent class for the FinBot platform"""
 
+import asyncio
 import json
 import logging
 import secrets
@@ -142,8 +143,9 @@ class BaseAgent(ABC):
                                         tool_call_name,
                                         tool_call["arguments"],
                                     )
-                                    function_output = await callable_fn(
-                                        **tool_call["arguments"]
+                                    function_output = await asyncio.wait_for(
+                                        callable_fn(**tool_call["arguments"]),
+                                        timeout=settings.AGENT_TOOL_TIMEOUT,
                                     )
                                     logger.debug("Function output: %s", function_output)
                                     if tool_call_name == "complete_task":
@@ -153,6 +155,16 @@ class BaseAgent(ABC):
                                             task_result=function_output
                                         )
                                         return function_output
+                                except asyncio.TimeoutError:
+                                    logger.error(
+                                        "Tool call %s timed out after %ds",
+                                        tool_call_name,
+                                        settings.AGENT_TOOL_TIMEOUT,
+                                    )
+                                    function_output = {
+                                        "error": f"Tool {tool_call_name} timed out "
+                                        f"after {settings.AGENT_TOOL_TIMEOUT}s",
+                                    }
                                 except Exception as e:  # pylint: disable=broad-exception-caught
                                     logger.error(
                                         "Tool call %s failed: %s", tool_call["name"], e

--- a/finbot/config.py
+++ b/finbot/config.py
@@ -99,6 +99,7 @@ class Settings(BaseSettings):
 
     # Agent Config
     AGENT_MAX_ITERATIONS: int = 10
+    AGENT_TOOL_TIMEOUT: int = 60  # seconds
 
     # OpenAI Config
     OPENAI_API_KEY: str = ""

--- a/tests/unit/agents/test_tool_timeout.py
+++ b/tests/unit/agents/test_tool_timeout.py
@@ -1,0 +1,47 @@
+"""Tests for agent tool call timeout.
+
+Covers:
+- Issue #201: Agent tool calls have no timeout, allowing indefinite blocking
+"""
+
+import asyncio
+
+import pytest
+
+from finbot.config import Settings
+
+
+def test_agent_tool_timeout_setting_exists():
+    """AGENT_TOOL_TIMEOUT setting should exist with a reasonable default."""
+    s = Settings(DEBUG=True)
+    assert hasattr(s, "AGENT_TOOL_TIMEOUT")
+    assert s.AGENT_TOOL_TIMEOUT > 0
+
+
+def test_agent_tool_timeout_default_value():
+    """Default timeout should be 60 seconds."""
+    s = Settings(DEBUG=True)
+    assert s.AGENT_TOOL_TIMEOUT == 60
+
+
+@pytest.mark.asyncio
+async def test_wait_for_timeout_mechanism():
+    """asyncio.wait_for should raise TimeoutError for slow tool calls."""
+
+    async def slow_tool(**kwargs):
+        await asyncio.sleep(10)
+        return {"result": "should not reach"}
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(slow_tool(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_allows_fast_calls():
+    """asyncio.wait_for should not interfere with fast tool calls."""
+
+    async def fast_tool(**kwargs):
+        return {"result": "success"}
+
+    result = await asyncio.wait_for(fast_tool(), timeout=5)
+    assert result == {"result": "success"}


### PR DESCRIPTION
## Summary
- Wrap agent tool calls with `asyncio.wait_for()` using configurable `AGENT_TOOL_TIMEOUT` (default 60s)
- Handle `asyncio.TimeoutError` explicitly, returning a clear error message to the LLM instead of hanging
- Add `AGENT_TOOL_TIMEOUT` setting to `config.py` for configurability

Fixes #201

## Test plan
- [x] `test_agent_tool_timeout_setting_exists` — setting exists with positive default
- [x] `test_agent_tool_timeout_default_value` — default is 60 seconds
- [x] `test_wait_for_timeout_mechanism` — slow calls raise TimeoutError
- [x] `test_wait_for_allows_fast_calls` — fast calls complete normally