### PR TITLE
fix PR Description: Enforce 10,000 Character Limit on Fraud Agent Notes

### DIFF
--- a/finbot/tools/data/fraud.py
+++ b/finbot/tools/data/fraud.py
@@ -213,6 +213,14 @@ async def update_fraud_agent_notes(
         vendor_id,
         agent_notes,
     )
+
+    if not agent_notes or not agent_notes.strip():
+        raise ValueError("Notes cannot be empty or whitespace only")
+    if len(agent_notes) > 10000:
+        raise ValueError("Notes exceed maximum length of 10,000 characters")
+    if "[Fraud Agent]" in agent_notes:
+        raise ValueError("Notes cannot contain the protected prefix '[Fraud Agent]'")
+
     with db_session() as db:
         vendor_repo = VendorRepository(db, session_context)
         vendor = vendor_repo.get_vendor(vendor_id)


### PR DESCRIPTION
Fixes #229
Fixes #230

### Description
Implemented character limit validation for `update_fraud_agent_notes` to address boundary issues reported in **#82** and **#83** (FRAUD-NOTES-007).

This ensures that the notes field does not grow indefinitely and remains within reasonable limits for the audit trail.

### Related Issues

- https://github.com/GenAI-Security-Project/finbot-ctf/issues/229 Note of 10,000 characters is accepted; 10,001 characters is rejected  
- 
- https://github.com/GenAI-Security-Project/finbot-ctf/issues/230 Note of 9,999 characters is accepted  

---

### Changes
**File:** `finbot/tools/data/fraud.py`

Added validation logic to `update_fraud_agent_notes`:

- **Length Check:** Raises `ValueError` if notes exceed 10,000 characters  
- **Content Sanitization:**  
  - Prevents empty/whitespace-only notes  
  - Prevents unauthorized `[Fraud Agent]` prefix injection  

---

### Fix Implemented
```python
if not agent_notes or not agent_notes.strip():
    raise ValueError("Notes cannot be empty or whitespace only")

if len(agent_notes) > 10000:
    raise ValueError("Notes exceed maximum length of 10,000 characters")

if "[Fraud Agent]" in agent_notes:
    raise ValueError("Notes cannot contain the protected prefix '[Fraud Agent]'")
```

---

### Verification
- Verified boundary condition for exactly **10,000 characters** 
- Verified **9,999 characters** is accepted 
- Verified **10,001 characters** raises `ValueError` 