### PR TITLE
fix Bug_084,086,092 - Enforce Validation for Vendor Status and Risk Level

### DIFF
--- a/finbot/tools/data/vendor.py
+++ b/finbot/tools/data/vendor.py
@@ -70,6 +70,19 @@ async def update_vendor_status(
         risk_level,
         agent_notes,
     )
+
+    valid_statuses = {"pending", "active", "inactive"}
+    if status not in valid_statuses:
+        raise ValueError(
+            f"Invalid status: {status!r}. Must be one of {valid_statuses}"
+        )
+
+    valid_risk_levels = {"low", "medium", "high"}
+    if risk_level not in valid_risk_levels:
+        raise ValueError(
+            f"Invalid risk_level: {risk_level!r}. Must be one of {valid_risk_levels}"
+        )
+
     with db_session() as db:
         vendor_repo = VendorRepository(db, session_context)
         vendor = vendor_repo.get_vendor(vendor_id)


### PR DESCRIPTION

### Summary
Implements strict validation for `status` and `risk_level` fields in `update_vendor_status` to ensure data integrity and prevent invalid inputs from propagating to downstream systems.

---

### Related Issues

Fixes #231 ,Fixes #233 ,Fixes #239 

- https://github.com/GenAI-Security-Project/finbot-ctf/issues/231 & https://github.com/GenAI-Security-Project/finbot-ctf/issues/233

>   - Ensures `status` is one of {"pending", "active", "inactive"}  
>   - Enforces lowercase values only  
>   - Rejects `None` and mixed-case inputs (e.g., "Active")

- https://github.com/GenAI-Security-Project/finbot-ctf/issues/239

>   - Ensures `risk_level` is one of {"low", "medium", "high"}  
>   - Enforces lowercase values only  
>   - Rejects mixed-case inputs (e.g., "Low")

---

### Changes

**File:** `finbot/tools/data/vendor.py`  
Added validation checks in `update_vendor_status`:

```python
valid_statuses = {"pending", "active", "inactive"}
if status not in valid_statuses:
    raise ValueError(f"Invalid status: {status!r}. Must be one of {valid_statuses}")

valid_risk_levels = {"low", "medium", "high"}
if risk_level not in valid_risk_levels:
    raise ValueError(f"Invalid risk_level: {risk_level!r}. Must be one of {valid_risk_levels}")
```

### Verification
- Verified `status` rejects `None` and mixed-case inputs  
- Verified `risk_level` rejects mixed-case inputs  
- Verified valid inputs are accepted  
- Verified invalid inputs raise `ValueError`  