### PR TITLE
fix Bug_110,111- ToolPoisoning Detectors: Support String Overrides 

### DIFF
--- a/finbot/ctf/detectors/implementations/tool_poisoning_deletion.py
+++ b/finbot/ctf/detectors/implementations/tool_poisoning_deletion.py
@@ -150,7 +150,8 @@ class ToolPoisoningDeletionDetector(BaseDetector):
 
         override_entry = overrides[poison_tool]
         has_description = bool(
-            isinstance(override_entry, dict) and override_entry.get("description")
+            (isinstance(override_entry, dict) and override_entry.get("description"))
+            or (isinstance(override_entry, str) and override_entry.strip())
         )
         if not has_description:
             return DetectionResult(

--- a/finbot/ctf/detectors/implementations/tool_poisoning_exfil.py
+++ b/finbot/ctf/detectors/implementations/tool_poisoning_exfil.py
@@ -185,7 +185,8 @@ class ToolPoisoningExfilDetector(BaseDetector):
 
         override_entry = overrides[poison_tool]
         has_description = bool(
-            isinstance(override_entry, dict) and override_entry.get("description")
+            (isinstance(override_entry, dict) and override_entry.get("description"))
+            or (isinstance(override_entry, str) and override_entry.strip())
         )
         if not has_description:
             return DetectionResult(


### PR DESCRIPTION

This PR resolves two issues in tool poisoning detectors that caused silent detection failures for valid YAML string overrides.
---
Fixes #301 ,Fixes #302 

- https://github.com/GenAI-Security-Project/finbot-ctf/issues/301 & 
- https://github.com/GenAI-Security-Project/finbot-ctf/issues/302

**Problem:**  
Both `ToolPoisoningExfilDetector` and `ToolPoisoningDeletionDetector` failed to recognize tool overrides stored as plain strings (valid YAML). They only looked for dictionary objects.

**Fix:**  
Updated Gate 1 logic in `tool_poisoning_exfil.py` and `tool_poisoning_deletion.py` to accept either a `dict` or a non-empty `str` as a valid tool poison description.

### 1. tool_poisoning_exfil.py 
```
has_description = bool(
            (isinstance(override_entry, dict) and override_entry.get("description"))
           or (isinstance(override_entry, str) and override_entry.strip())
          )
```
### 2. tool_poisoning_deletion.py
```
has_description = bool(
           (isinstance(override_entry, dict) and override_entry.get("description"))
           or (isinstance(override_entry, str) and override_entry.strip())
         )
```
---

## Verification

- Verified string-based tool overrides are correctly detected  
- Confirmed expected behavior via existing unit tests  

---