### PR TITLE
fix Bug_96,97,98-Enforce Canonical Validation for Invoice Status

### DIFF
--- a/finbot/tools/data/invoice.py
+++ b/finbot/tools/data/invoice.py
@@ -48,6 +48,11 @@ async def update_invoice_status(
         status,
         agent_notes,
     )
+    VALID_STATUSES = {"submitted", "processing", "approved", "rejected", "paid"}
+    if status not in VALID_STATUSES:
+        raise ValueError(
+            f"Invalid status: {status!r}. Must be one of {VALID_STATUSES}"
+        )
     with db_session() as db:
         invoice_repo = InvoiceRepository(db, session_context)
         invoice = invoice_repo.get_invoice(invoice_id)


### PR DESCRIPTION

### Summary
Adds strict validation for `status` in `update_invoice_status` to ensure only canonical values are accepted and prevent invalid or malformed inputs.
---
Fixes #243 ,Fixes #244 ,Fixes #245 



### Related Issues
-  https://github.com/GenAI-Security-Project/finbot-ctf/issues/243
- https://github.com/GenAI-Security-Project/finbot-ctf/issues/244
- https://github.com/GenAI-Security-Project/finbot-ctf/issues/245 

---

### Changes

**File:** `update_invoice_status`

- Added exact-match validation using a predefined set of allowed values  
- Enforces strict canonical format (lowercase, no whitespace)  

```python
VALID_STATUSES = {"submitted", "processing", "approved", "rejected", "paid"}

if status not in VALID_STATUSES:
    raise ValueError(
        f"Invalid status: {status!r}. Must be one of {VALID_STATUSES}"
    )
```
---

### Verification

- Verified `None` input raises `ValueError`  
- Verified whitespace-padded inputs are rejected  
- Verified mixed/uppercase inputs are rejected  
- Verified only valid canonical statuses are accepted  