### PR TITLE
 fix Bug_99,100,101-Fix Agent Notes Validation

### DIFF
--- a/finbot/tools/data/invoice.py
+++ b/finbot/tools/data/invoice.py
@@ -82,6 +82,11 @@ async def update_invoice_agent_notes(
         invoice_id,
         agent_notes,
     )
+    if not agent_notes or not agent_notes.strip():
+        raise ValueError("agent_notes must not be empty or whitespace-only")
+    if "[Fraud Agent]" in agent_notes:
+        raise ValueError("agent_notes must not contain reserved agent prefixes")
+
     with db_session() as db:
         invoice_repo = InvoiceRepository(db, session_context)
         invoice = invoice_repo.get_invoice(invoice_id)


### PR DESCRIPTION

### Summary
Adds validation for `agent_notes` to ensure inputs are meaningful and prevent misuse of reserved prefixes in the audit trail.

---

Fixes #246 ,Fixes #247 ,Fixes #248 

### Related Issues

- https://github.com/GenAI-Security-Project/finbot-ctf/issues/246
- https://github.com/GenAI-Security-Project/finbot-ctf/issues/247
- https://github.com/GenAI-Security-Project/finbot-ctf/issues/248
---

### Changes

#### Agent Notes Validation
- Rejects empty or whitespace-only notes  
- Prevents use of reserved prefix `[Fraud Agent]`  

```python
if not agent_notes or not agent_notes.strip():
    raise ValueError("agent_notes must not be empty or whitespace-only")

if "[Fraud Agent]" in agent_notes:
    raise ValueError("agent_notes must not contain reserved agent prefixes")
```

---

### Verification

- Verified whitespace-only notes are rejected  
- Verified `None` and empty notes are rejected  
- Verified `[Fraud Agent]` prefix is rejected  
- Confirmed validation raises `ValueError` as expected  