### PR TITLE
fix: Windows cross-platform support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF line endings for shell scripts (prevents CRLF breakage in Linux containers)
+*.sh text eol=lf
+docker/entrypoint.sh text eol=lf

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-echo "⏫ Running bootstrap (migrations, seeding, definitions)..."
+echo "Running bootstrap (migrations, seeding, definitions)..."
 python scripts/bootstrap.py
 
 exec "$@"

--- a/finbot/config.py
+++ b/finbot/config.py
@@ -3,9 +3,15 @@
 """
 
 import hashlib
+import io
 import os
+import sys
 from typing import Any, Literal
 from urllib.parse import urlparse
+
+# Ensure stdout can handle Unicode on all platforms (Windows cp1252 fix)
+if sys.stdout.encoding and sys.stdout.encoding.lower().replace("-", "") != "utf8":
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
 
 from pydantic import ConfigDict, model_validator
 from pydantic_settings import BaseSettings

--- a/scripts/check_prerequisites.py
+++ b/scripts/check_prerequisites.py
@@ -10,9 +10,14 @@ Usage:
     python scripts/check_prerequisites.py
 """
 
+import io
 import shutil
 import subprocess
 import sys
+
+# Ensure stdout can handle Unicode on all platforms (Windows cp1252 fix)
+if sys.stdout.encoding and sys.stdout.encoding.lower().replace("-", "") != "utf8":
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
 
 
 def check_python() -> tuple[bool, str]:

--- a/tests/integration/apps/web/test_templates.py
+++ b/tests/integration/apps/web/test_templates.py
@@ -34,7 +34,7 @@ class TestTemplateRendering:
 
     def test_pages_render_without_errors(self, integration_client: TestClient):
         """Test that pages render without template errors."""
-        pages = ["/", "/about", "/contact"]
+        pages = ["/demo/cineflow/", "/demo/cineflow/about", "/demo/cineflow/contact"]
 
         for page in pages:
             response = integration_client.get(page)


### PR DESCRIPTION
## Summary

Fixes four issues that prevent a clean setup on Windows. See #309 for full details.

- **UTF-8 stdout wrapper**: `config.py` and `check_prerequisites.py` crash on Windows because `cp1252` cannot encode emoji characters. Added a stdout wrapper that switches to UTF-8 when needed.
- **`.gitattributes`**: Git on Windows converts `entrypoint.sh` to CRLF. The Linux container then reads `set -e\r` and crashes. Added `.gitattributes` to force LF on shell scripts.
- **Entrypoint emoji**: Removed emoji from `docker/entrypoint.sh` to avoid encoding issues in minimal container shells.
- **Stale test route**: `test_pages_render_without_errors` hit `/about` and `/contact` at the root, but the web router moved to `/demo/cineflow/`. Updated the test paths.

## Test plan

- [x] `python scripts/check_prerequisites.py` runs without `UnicodeEncodeError` on Windows
- [x] `uv run python scripts/db.py setup` runs without `UnicodeEncodeError` on Windows
- [x] `test_pages_render_without_errors` passes (was failing with 404)
- [x] All 6 template integration tests pass

Closes #309