### PR TITLE
fix(tools): enforce strict action allowlist in manage_storage to prevent RCE/destructive commands (fixes #371)

### DIFF
--- a/finbot/mcp/servers/systemutils/server.py
+++ b/finbot/mcp/servers/systemutils/server.py
@@ -34,6 +34,33 @@ DEFAULT_CONFIG: dict[str, Any] = {
 }
 
 
+# Module-level implementation for testing
+def manage_storage(action: str, target: str, namespace: str = "unknown") -> dict[str, Any]:
+    """Manage file storage operations.
+
+    Perform storage management actions on the specified target path.
+    Actions: 'check', 'cleanup', 'archive', 'restore'.
+    """
+    ALLOWED_ACTIONS = {"check", "cleanup", "archive", "restore"}
+    if action not in ALLOWED_ACTIONS:
+        raise ValueError(f"Action '{action}' is not permitted. Allowed: {ALLOWED_ACTIONS}")
+
+    logger.warning(
+        "SystemUtils manage_storage called with action='%s', target='%s' by namespace='%s'",
+        action,
+        target,
+        namespace,
+    )
+
+    return {
+        "action": action,
+        "target": target,
+        "status": "completed",
+        "message": f"Storage operation '{action}' completed on '{target}'",
+        "bytes_affected": 0,
+        "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+
 def create_systemutils_server(
     session_context: SessionContext,
     server_config: dict[str, Any] | None = None,
@@ -65,28 +92,14 @@ def create_systemutils_server(
             "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         }
 
-    @mcp.tool
-    def manage_storage(action: str, target: str) -> dict[str, Any]:
+    @mcp.tool("manage_storage")
+    def manage_storage_tool(action: str, target: str) -> dict[str, Any]:
         """Manage file storage operations.
 
         Perform storage management actions on the specified target path.
         Actions: 'check', 'cleanup', 'archive', 'restore'.
         """
-        logger.warning(
-            "SystemUtils manage_storage called with action='%s', target='%s' by namespace='%s'",
-            action,
-            target,
-            session_context.namespace,
-        )
-
-        return {
-            "action": action,
-            "target": target,
-            "status": "completed",
-            "message": f"Storage operation '{action}' completed on '{target}'",
-            "bytes_affected": 0,
-            "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-        }
+        return manage_storage(action, target, session_context.namespace)
 
     @mcp.tool
     def rotate_logs(service: str, options: str = "") -> dict[str, Any]:


### PR DESCRIPTION
Resolves #371 

### Summary of Changes
This PR addresses the critical missing guardrail in the `manage_storage` tool that previously allowed destructive shell commands (like `rm -rf /`) to be passed without validation.

* **Strict Allowlist:** Implemented an O(1) set-based allowlist (`{"check", "cleanup", "archive", "restore"}`) at the entry point of the function.
* **Proactive Test Coverage:** I noticed the `tests/unit/mcp/test_systemutils.py` file mentioned in the issue didn't exist on `main` yet, so I went ahead and created the test suite to fulfill the Acceptance Criteria. 

### Bugs Resolved
* **[MUST FIX] Bug_162 (Issue #371):** Prevents a poisoned agent from staging destructive filesystem operations or arbitrary command execution via the storage management tool.

### Test Plan
* `test_su_stor_001_returns_expected_fields` -> Passes (Valid actions still process normally)
* `test_su_stor_002_destructive_action_accepted_without_validation` -> Passes (Correctly raises `ValueError` for `rm -rf /`)

*(Note: The linting warnings regarding `fastmcp` imports are pre-existing on the environment and unrelated to this logic patch.)*

cc @steadhac @saikishu — Since this patches a high-severity destructive action, I wanted to get this up quickly!