### PR TITLE
Fix(findrive): reject folder path traversal sequences in upload_file

### DIFF
--- a/finbot/mcp/servers/findrive/server.py
+++ b/finbot/mcp/servers/findrive/server.py
@@ -55,10 +55,11 @@ def create_findrive_server(
         retrieval. Use this for storing invoice PDFs, receipts, and supporting
         documentation.
         """
-                max_size = config.get("max_file_size_kb", 500) * 1024
+        max_size = config.get("max_file_size_kb", 500) * 1024
         if len(content.encode("utf-8")) > max_size:
             return {"error": f"File exceeds maximum size of {config.get('max_file_size_kb', 500)}KB"}
 
+        # Validate folder path to prevent path traversal
         if ".." in folder or not folder.startswith("/"):
             return {"error": "folder path contains invalid sequences or must be an absolute path"}
 

--- a/finbot/mcp/servers/findrive/server.py
+++ b/finbot/mcp/servers/findrive/server.py
@@ -55,9 +55,12 @@ def create_findrive_server(
         retrieval. Use this for storing invoice PDFs, receipts, and supporting
         documentation.
         """
-        max_size = config.get("max_file_size_kb", 500) * 1024
+                max_size = config.get("max_file_size_kb", 500) * 1024
         if len(content.encode("utf-8")) > max_size:
             return {"error": f"File exceeds maximum size of {config.get('max_file_size_kb', 500)}KB"}
+
+        if ".." in folder or not folder.startswith("/"):
+            return {"error": "folder path contains invalid sequences or must be an absolute path"}
 
         with db_session() as db:
             repo = FinDriveFileRepository(db, session_context)


### PR DESCRIPTION
## Summary
Fixes #368  
Adds folder path validation to `upload_file` to reject paths containing `..` or not starting with `/`.

## Problem
The `upload_file` tool stored any `folder` string without validation, allowing callers to specify paths like `../../../secrets`. This could enable path traversal attacks if the folder path is later used in filesystem operations.

## Root Cause
`upload_file` passes the `folder` parameter directly to `repo.create_file` without sanitisation. The repository stores the string verbatim, making it possible to persist traversal sequences.

## Solution
Insert a validation block after the file size check that returns an error if:
- The folder path contains `..`
- The folder path does not start with `/`

This rejects invalid paths early and matches the existing error-handling pattern (returning a dict with an `"error"` key).

## Impact
- No breaking changes for valid absolute paths (e.g., `/invoices`).
- Minimal diff surface – only 4 lines added.
- Deterministic behaviour for invalid inputs.
- Improved correctness and security.

## Testing
- Ran `pytest tests/unit/mcp/test_findrive.py::TestUploadFile::test_fd_upload_009_path_traversal_in_folder_accepted -v` – passes.
- Ran `pytest tests/unit/mcp/test_findrive.py::TestUploadFile::test_fd_upload_001_upload_returns_file_id_and_metadata -v` – passes.