### PR TITLE
Fix(finstripe): add vendor ownership check to get_transfer

### DIFF
--- a/finbot/mcp/servers/finstripe/server.py
+++ b/finbot/mcp/servers/finstripe/server.py
@@ -92,7 +92,7 @@ def create_finstripe_server(
                 "description": txn.description,
             }
 
-       @mcp.tool
+          @mcp.tool
     def get_transfer(transfer_id: str) -> dict[str, Any]:
         """Retrieve transfer details by transfer ID.
 
@@ -108,7 +108,7 @@ def create_finstripe_server(
                     "transfer_id": transfer_id,
                 }
 
-           
+            # Vendor sessions must own the transfer
             if hasattr(session_context, 'current_vendor_id') and session_context.current_vendor_id is not None:
                 if txn.vendor_id != session_context.current_vendor_id:
                     return {
@@ -117,7 +117,6 @@ def create_finstripe_server(
                     }
 
             return txn.to_dict()
-
     @mcp.tool
     def get_account_balance(account_id: str) -> dict[str, Any]:
         """Check available balance for an account.

--- a/finbot/mcp/servers/finstripe/server.py
+++ b/finbot/mcp/servers/finstripe/server.py
@@ -92,7 +92,7 @@ def create_finstripe_server(
                 "description": txn.description,
             }
 
-    @mcp.tool
+       @mcp.tool
     def get_transfer(transfer_id: str) -> dict[str, Any]:
         """Retrieve transfer details by transfer ID.
 
@@ -107,6 +107,14 @@ def create_finstripe_server(
                     "error": f"Transfer {transfer_id} not found",
                     "transfer_id": transfer_id,
                 }
+
+           
+            if hasattr(session_context, 'current_vendor_id') and session_context.current_vendor_id is not None:
+                if txn.vendor_id != session_context.current_vendor_id:
+                    return {
+                        "error": f"Transfer {transfer_id} not found",
+                        "transfer_id": transfer_id,
+                    }
 
             return txn.to_dict()
 

--- a/finbot/mcp/servers/finstripe/server.py
+++ b/finbot/mcp/servers/finstripe/server.py
@@ -92,7 +92,7 @@ def create_finstripe_server(
                 "description": txn.description,
             }
 
-          @mcp.tool
+    @mcp.tool
     def get_transfer(transfer_id: str) -> dict[str, Any]:
         """Retrieve transfer details by transfer ID.
 
@@ -117,6 +117,7 @@ def create_finstripe_server(
                     }
 
             return txn.to_dict()
+            
     @mcp.tool
     def get_account_balance(account_id: str) -> dict[str, Any]:
         """Check available balance for an account.


### PR DESCRIPTION
## Summary
Fixes #325  
Adds missing vendor ownership check in `get_transfer` to prevent vendor portal sessions from retrieving another vendor's transfer.

## Problem
Vendor portal sessions could retrieve any transfer in the namespace by ID because `get_transfer` did not verify that the transfer belongs to the calling vendor. This exposes payment amounts, invoice IDs, and other sensitive data across vendors.

## Root Cause
The tool only relies on namespace scoping provided by the repository. No additional vendor-level ownership check is performed, leaving a validation gap for vendor sessions.

## Solution
- In `get_transfer`, after retrieving the transaction, check if the session is a vendor session (`hasattr(session_context, 'current_vendor_id') and session_context.current_vendor_id is not None`).
- If it is a vendor session, compare `txn.vendor_id` with `session_context.current_vendor_id`; if they differ, return a “not found” error.
- Admin sessions (no `current_vendor_id`) are unaffected.

## Impact
-  Vendor portal sessions can only see their own transfers.
-  Admin sessions retain full visibility.
-  No changes to other tools or database logic.
-  Minimal diff (4 lines added).

## Testing
- `test_mcp_vendor_008_vendor_session_can_get_transfer_of_different_vendor` now passes.
- `test_mcp_vendor_001_namespace_isolation` and `test_mcp_get_001_admin_can_get_any_transfer` continue to pass.