### PR TITLE
UI: Unify internal scrollbar styling across vendor, admin, and ctf

### DIFF
--- a/finbot/apps/admin/templates/base.html
+++ b/finbot/apps/admin/templates/base.html
@@ -82,7 +82,7 @@
 
     <div class="flex flex-1 min-h-0 relative z-10 overflow-hidden bg-portal-bg-primary">
         <!-- Sidebar -->
-        <aside id="sidebar" class="ai-sidebar w-80 flex-shrink-0 flex flex-col overflow-y-auto border-r border-admin-primary/20 bg-portal-bg-secondary/50">
+        <aside id="sidebar" class="ai-sidebar app-scrollbar w-80 flex-shrink-0 flex flex-col overflow-y-auto border-r border-admin-primary/20 bg-portal-bg-secondary/50">
             <!-- Logo -->
             <div class="sidebar-logo-section p-6 border-b border-admin-primary/20">
                 <div class="flex items-center space-x-3">
@@ -242,7 +242,7 @@
             </header>
 
             <!-- Content -->
-            <div class="flex-1 overflow-auto p-6">
+            <div class="app-scrollbar flex-1 overflow-auto p-6">
                 {% block content %}{% endblock %}
             </div>
         </main>

--- a/finbot/apps/admin/templates/pages/findrive.html
+++ b/finbot/apps/admin/templates/pages/findrive.html
@@ -72,7 +72,7 @@
             <p class="text-text-secondary mb-4">Use the <strong>Finance Co-Pilot</strong> to generate report artifacts</p>
         </div>
     </div>
-    <div id="drive-sidecar" class="drive-sidecar hidden"></div>
+    <div id="drive-sidecar" class="drive-sidecar app-scrollbar hidden"></div>
 </div>
 
 <!-- Fullscreen Viewer Modal -->
@@ -93,7 +93,7 @@
             </button>
         </div>
     </div>
-    <div class="fd-viewport">
+    <div class="fd-viewport app-scrollbar">
         <div id="viewer-paper" class="fd-paper"></div>
     </div>
 </div>

--- a/finbot/apps/ctf/templates/base.html
+++ b/finbot/apps/ctf/templates/base.html
@@ -73,7 +73,7 @@
 
     <div class="flex min-h-screen relative z-10">
         <!-- CTF Sidebar:(matching vendor portal style)-->
-        <aside id="sidebar" class="ai-sidebar w-80 flex-shrink-0 flex flex-col sticky top-0 h-screen overflow-y-auto border-r border-ctf-primary/20 bg-portal-bg-secondary/50">
+        <aside id="sidebar" class="ai-sidebar app-scrollbar w-80 flex-shrink-0 flex flex-col sticky top-0 h-screen overflow-y-auto border-r border-ctf-primary/20 bg-portal-bg-secondary/50">
             <!-- Logo Section -->
             <div class="sidebar-logo-section p-6 border-b border-ctf-primary/20">
                 <div class="flex items-center space-x-3">

--- a/finbot/apps/ctf/templates/pages/activity.html
+++ b/finbot/apps/ctf/templates/pages/activity.html
@@ -149,7 +149,7 @@
                 </svg>
             </button>
         </div>
-        <div id="mobile-detail-events" class="space-y-2 max-h-[60vh] overflow-y-auto"></div>
+        <div id="mobile-detail-events" class="app-scrollbar space-y-2 max-h-[60vh] overflow-y-auto"></div>
     </div>
 </div>
 

--- a/finbot/apps/ctf/templates/pages/toolkit.html
+++ b/finbot/apps/ctf/templates/pages/toolkit.html
@@ -110,13 +110,13 @@
         <div class="flex gap-4" style="height: calc(100vh - 420px); min-height: 400px;">
             <!-- Message List -->
             <div class="w-2/5 flex flex-col glass-card overflow-hidden">
-                <div id="dead-drop-list" class="flex-1 overflow-y-auto divide-y divide-white/5">
+                <div id="dead-drop-list" class="app-scrollbar flex-1 overflow-y-auto divide-y divide-white/5">
                 </div>
             </div>
 
             <!-- Reading Pane -->
             <div class="w-3/5 flex flex-col glass-card overflow-hidden">
-                <div id="reading-pane" class="flex-1 overflow-y-auto p-6">
+                <div id="reading-pane" class="app-scrollbar flex-1 overflow-y-auto p-6">
                     <div id="reading-empty" class="flex flex-col items-center justify-center h-full text-center">
                         <div class="w-16 h-16 rounded-full bg-ctf-primary/10 flex items-center justify-center mb-4">
                             <svg class="w-8 h-8 text-ctf-primary/40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -180,13 +180,13 @@
         <div class="flex gap-4" style="height: calc(100vh - 420px); min-height: 400px;">
             <!-- Capture List -->
             <div class="w-2/5 flex flex-col glass-card overflow-hidden">
-                <div id="exfil-list" class="flex-1 overflow-y-auto divide-y divide-white/5">
+                <div id="exfil-list" class="app-scrollbar flex-1 overflow-y-auto divide-y divide-white/5">
                 </div>
             </div>
 
             <!-- Detail Pane -->
             <div class="w-3/5 flex flex-col glass-card overflow-hidden">
-                <div id="exfil-pane" class="flex-1 overflow-y-auto p-6">
+                <div id="exfil-pane" class="app-scrollbar flex-1 overflow-y-auto p-6">
                     <div id="exfil-pane-empty" class="flex flex-col items-center justify-center h-full text-center">
                         <div class="w-16 h-16 rounded-full bg-ctf-secondary/10 flex items-center justify-center mb-4">
                             <svg class="w-8 h-8 text-ctf-secondary/40" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/finbot/apps/vendor/templates/base.html
+++ b/finbot/apps/vendor/templates/base.html
@@ -69,7 +69,7 @@
 
     <div class="flex min-h-screen relative z-10 bg-portal-bg-primary">
         <!-- Sidebar -->
-        <aside id="sidebar" class="ai-sidebar w-80 flex-shrink-0 flex flex-col sticky top-0 h-screen overflow-y-auto">
+        <aside id="sidebar" class="ai-sidebar app-scrollbar w-80 flex-shrink-0 flex flex-col sticky top-0 h-screen overflow-y-auto">
             <!-- Logo Section -->
             <div class="sidebar-logo-section p-6 border-b border-vendor-primary/20">
                 <div class="flex items-center space-x-3">

--- a/finbot/apps/vendor/templates/pages/assistant.html
+++ b/finbot/apps/vendor/templates/pages/assistant.html
@@ -72,7 +72,7 @@
                     </svg>
                 </button>
             </div>
-            <div id="chat-picker-grid" class="p-4 overflow-y-auto max-h-[calc(60vh-110px)] grid grid-cols-3 sm:grid-cols-4 gap-3">
+            <div id="chat-picker-grid" class="app-scrollbar p-4 overflow-y-auto max-h-[calc(60vh-110px)] grid grid-cols-3 sm:grid-cols-4 gap-3">
                 <p class="col-span-full text-center text-text-secondary py-8">Loading files...</p>
             </div>
             <div class="p-3 border-t border-vendor-primary/20 flex justify-end">

--- a/finbot/apps/vendor/templates/pages/findrive.html
+++ b/finbot/apps/vendor/templates/pages/findrive.html
@@ -247,6 +247,8 @@
     border-left: 1px solid rgba(255,255,255,0.06);
     background: rgba(255,255,255,0.02);
     overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 212, 255, 0.35) transparent;
 }
 .sc-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid rgba(255,255,255,0.06); }
 .sc-header-title { font-size: 13px; font-weight: 600; color: #e2e8f0; }
@@ -304,7 +306,37 @@
 /* ================================================================
    PAPER VIEWPORT + PAPER
    ================================================================ */
-.fd-viewport { flex: 1; overflow: auto; background: #374151; padding: 32px 16px; }
+.fd-viewport {
+    flex: 1;
+    overflow: auto;
+    background: #374151;
+    padding: 32px 16px;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 212, 255, 0.35) transparent;
+}
+
+.drive-sidecar::-webkit-scrollbar,
+.fd-viewport::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+.drive-sidecar::-webkit-scrollbar-track,
+.fd-viewport::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.drive-sidecar::-webkit-scrollbar-thumb,
+.fd-viewport::-webkit-scrollbar-thumb {
+    background: linear-gradient(180deg, rgba(0, 212, 255, 0.35), rgba(124, 58, 237, 0.35));
+    border-radius: 999px;
+    border: 1px solid rgba(30, 41, 59, 0.6);
+}
+
+.drive-sidecar::-webkit-scrollbar-thumb:hover,
+.fd-viewport::-webkit-scrollbar-thumb:hover {
+    background: linear-gradient(180deg, rgba(0, 212, 255, 0.55), rgba(124, 58, 237, 0.55));
+}
 .fd-paper {
     background: #ffffff; color: #1e293b;
     max-width: 816px; margin: 0 auto;

--- a/finbot/apps/vendor/templates/pages/invoices.html
+++ b/finbot/apps/vendor/templates/pages/invoices.html
@@ -192,7 +192,7 @@
                 </button>
             </div>
         </div>
-        <div class="p-6 overflow-y-auto max-h-[calc(90vh-140px)]">
+        <div class="app-scrollbar p-6 overflow-y-auto max-h-[calc(90vh-140px)]">
             <form id="invoice-form" class="space-y-6">
                 <!-- CSRF Token -->
                 {{ csrf_token_field | safe }}
@@ -362,7 +362,7 @@
                 Processing Notes
             </h4>
             <div class="bg-portal-surface rounded-xl p-4 border border-vendor-secondary/20">
-                <div id="sidecar-agent-notes" class="text-sm text-text-bright leading-relaxed max-h-48 overflow-y-auto">
+                <div id="sidecar-agent-notes" class="app-scrollbar text-sm text-text-bright leading-relaxed max-h-48 overflow-y-auto">
                     <span class="text-text-secondary italic">No processing notes available.</span>
                 </div>
             </div>
@@ -426,7 +426,7 @@
                 </svg>
             </button>
         </div>
-        <div id="picker-files-grid" class="p-4 overflow-y-auto max-h-[calc(70vh-120px)] grid grid-cols-3 sm:grid-cols-4 gap-3">
+        <div id="picker-files-grid" class="app-scrollbar p-4 overflow-y-auto max-h-[calc(70vh-120px)] grid grid-cols-3 sm:grid-cols-4 gap-3">
             <p class="col-span-full text-center text-text-secondary py-8">Loading files...</p>
         </div>
         <div class="p-3 border-t border-vendor-primary/20 flex justify-end">

--- a/finbot/apps/vendor/templates/pages/profile.html
+++ b/finbot/apps/vendor/templates/pages/profile.html
@@ -214,7 +214,7 @@
                     </svg>
                     <span class="text-xs text-text-secondary uppercase tracking-wide">Review History</span>
                 </div>
-                <div id="agent-notes" class="text-sm text-text-bright leading-relaxed max-h-64 overflow-y-auto">
+                <div id="agent-notes" class="app-scrollbar text-sm text-text-bright leading-relaxed max-h-64 overflow-y-auto">
                     <span class="text-text-secondary italic">No notes available.</span>
                 </div>
             </div>
@@ -259,7 +259,7 @@
                 </button>
             </div>
         </div>
-        <div class="p-6 overflow-y-auto max-h-[calc(90vh-140px)]">
+        <div class="app-scrollbar p-6 overflow-y-auto max-h-[calc(90vh-140px)]">
             <form id="edit-profile-form" class="space-y-6">
                 <!-- CSRF Token -->
                 {{ csrf_token_field | safe }}

--- a/finbot/static/css/vendor/portal.css
+++ b/finbot/static/css/vendor/portal.css
@@ -2,6 +2,31 @@
  * FinBot Vendor Portal - Modern Financial Interface
  */
 
+/* App-wide internal scrollbar skin (vendor/admin/ctf) */
+.app-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 212, 255, 0.35) transparent;
+}
+
+.app-scrollbar::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+.app-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.app-scrollbar::-webkit-scrollbar-thumb {
+    background: linear-gradient(180deg, rgba(0, 212, 255, 0.35), rgba(124, 58, 237, 0.35));
+    border-radius: 999px;
+    border: 1px solid rgba(10, 10, 15, 0.5);
+}
+
+.app-scrollbar::-webkit-scrollbar-thumb:hover {
+    background: linear-gradient(180deg, rgba(0, 212, 255, 0.55), rgba(124, 58, 237, 0.55));
+}
+
 /* ==========================================================================
    CORE SYSTEM & VARIABLES
    ========================================================================== */


### PR DESCRIPTION
close #390
**Summary**
- Extended shared internal scrollbar styling to Admin and CTF in addition to Vendor.
- Applied vendor-scrollbar to key portal scroll containers:
  - Admin: sidebar, main content scroller, Findrive sidecar, Findrive viewport
  - CTF: sidebar, Activity mobile detail events, Toolkit dead-drop/exfil list and reading panes
  - Vendor: previously updated internal containers retained
- Preserved existing bespoke scrollbar styles in components that already define custom rules (e.g. messages/chat areas).

**Before**
<img width="200" height="550" alt="image" src="https://github.com/user-attachments/assets/2bcfb73b-0773-40b9-954c-ecc380546ce4" /><img width="300" height="545" alt="image" src="https://github.com/user-attachments/assets/337c3c9c-1f70-4588-be7c-5e9e4e884669" /><img width="400" height="328" alt="image" src="https://github.com/user-attachments/assets/899bbc08-f9bf-4bbd-87a8-b5ba2faf8aed" />

## After
<img width="500" height="329" alt="image" src="https://github.com/user-attachments/assets/970629af-61ff-4a19-9cf4-4615125681f5" />
<img width="400" height="642" alt="image" src="https://github.com/user-attachments/assets/cb7c3222-9c4a-46e7-a326-b3ec4f2b5567" />
