### PR TITLE
Fix(chat): resolve description=None TypeError in _call_start_workflow with minimal guard

### DIFF
--- a/finbot/agents/chat.py
+++ b/finbot/agents/chat.py
@@ -189,6 +189,8 @@ class ChatAssistantBase:
     ) -> str:
         if not self.background_tasks:
             return json.dumps({"error": "Workflow engine not available"})
+        if description is None or vendor_id is None:
+            return json.dumps({"error": "description and vendor_id are required"})
 
         from finbot.agents.runner import (
             run_orchestrator_agent,  # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
## Summary
Fixes #416

Guards `_call_start_workflow` against `description=None`, preventing an unhandled
`TypeError` that propagated as a 500 response with no structured error to the caller.

## Problem
When the LLM omits `description` from a `start_workflow` tool call, `description=None`
reaches `description[:100]` at `event_bus.emit_agent_event` — after `background_tasks.add_task`
has already executed — raising `TypeError: 'NoneType' object is not subscriptable`.

## Root Cause
No `None` guard existed between method entry and the first slice of `description`.
The existing `background_tasks` guard pattern was not extended to cover required string parameters.

## Solution
Add a single `None` guard for `description` and `vendor_id` immediately after the
`background_tasks` check — before any state mutation — returning structured error JSON.
Also resolves the shared fix location noted in TICKET 9 (`vendor_id=None`).

## Impact
- No breaking changes
- Minimal diff (+2 lines, 0 modified)
- Deterministic early return before any side effects
- Zero regression risk

## Testing
```bash
pytest tests/unit/agents/test_chat_assistant.py::TestBoundaryAndTypeValues::test_chat_boundary_012_description_none_crashes_before_dispatch -v
pytest tests/unit/agents/test_chat_assistant.py -v
```