### PR TITLE
Fix(network_request): reject empty or whitespace-only URL input

### DIFF
--- a/finbot/mcp/servers/systemutils/server.py
+++ b/finbot/mcp/servers/systemutils/server.py
@@ -144,13 +144,15 @@ def create_systemutils_server(
         Useful for verifying endpoint availability, testing webhooks, or
         checking external service connectivity.
         """
+       if not url or not url.strip():
+            raise ValueError("url must not be empty")
+
         logger.warning(
             "SystemUtils network_request called with url='%s', method='%s' by namespace='%s'",
             url,
             method,
             session_context.namespace,
         )
-
         return {
             "url": url,
             "method": method,

--- a/finbot/mcp/servers/systemutils/server.py
+++ b/finbot/mcp/servers/systemutils/server.py
@@ -144,7 +144,7 @@ def create_systemutils_server(
         Useful for verifying endpoint availability, testing webhooks, or
         checking external service connectivity.
         """
-       if not url or not url.strip():
+        if not url or not url.strip():
             raise ValueError("url must not be empty")
 
         logger.warning(
@@ -153,6 +153,7 @@ def create_systemutils_server(
             method,
             session_context.namespace,
         )
+
         return {
             "url": url,
             "method": method,


### PR DESCRIPTION
## Summary
Fixes #393  `network_request` accepted empty/whitespace URLs and silently 
returned `"completed"`, producing invalid mock records.

## Root Cause
No presence check existed on the `url` parameter. Any string  including `''` 
or `'   '`  bypassed all logic and reached the return block unchallenged.

## Fix
Added a two-condition guard as the **first statement** in `network_request`, 
before logging or any return path:
```python
if not url or not url.strip():
    raise ValueError("url must not be empty")
```

## Affected File
`finbot/mcp/servers/systemutils/server.py` → `network_request`

## Behavior Change
| Input       | Before       | After                        |
|-------------|--------------|------------------------------|
| `''`        |  completed  |  ValueError: url must not be empty |
| `'   '`     |  completed  |  ValueError: url must not be empty |
| valid URL   |  completed  |  completed (unchanged)      |

## Impact
- No breaking changes to valid usage
- 2 lines added, 0 lines removed
- No dependency or API contract changes
- Zero regression risk

## Testing
```bash
# Target fix
pytest tests/unit/mcp/test_systemutils.py::TestNetworkRequest::test_su_net_004_empty_url_accepted_without_validation -v

# Regression check
pytest tests/unit/mcp/test_systemutils.py::TestNetworkRequest::test_su_net_001_returns_expected_fields -v
```