### PR TITLE
Fix(findrive): resolve missing non-negative guard in list_files with minimal patch

### DIFF
--- a/finbot/mcp/servers/findrive/server.py
+++ b/finbot/mcp/servers/findrive/server.py
@@ -124,6 +124,9 @@ def create_findrive_server(
         Returns document metadata (not content) for files in the specified folder.
         Use get_file to retrieve the extracted text of a specific document.
         """
+        if limit < 0:
+            return {"error": f"limit must be non-negative, got {limit}"}
+
         with db_session() as db:
             repo = FinDriveFileRepository(db, session_context)
 


### PR DESCRIPTION
## Summary
Fixes #352
Adds a pre-DB guard to reject negative `limit` values in `list_files`.

## Problem
`list_files` accepted `limit < 0` without validation, forwarding it
to the database layer and producing undefined behaviour.

## Root Cause
No input guard existed before the `db_session()` call in `list_files`.
All other tools in this file guard against invalid input before
touching the DB; `list_files` was missing this check.

## Solution
Added two lines before `with db_session()`:
```python
if limit < 0:
    return {"error": f"limit must be non-negative, got {limit}"}
```
Pattern is identical to existing guards in `upload_file` and `get_file`.

## Impact
- No breaking changes
- Minimal diff (2 lines added)
- Deterministic behaviour
- Zero regression risk

## Testing
```bash
pytest tests/unit/mcp/test_findrive.py::TestIntFieldEdgeCases::test_fd_int_005_list_files_negative_limit_raises -v
pytest tests/unit/mcp/test_findrive.py::test_fd_list_001_returns_all_files -v
```