### PR TITLE
Fix(finstripe): reject vendor portal session with no vendor identity before transfer

### DIFF
--- a/finbot/mcp/servers/finstripe/server.py
+++ b/finbot/mcp/servers/finstripe/server.py
@@ -59,6 +59,9 @@ def create_finstripe_server(
         Transfers funds from the company account to a vendor's bank account.
         Returns the transfer details including a unique transfer ID for tracking.
         """
+        if _is_vendor_session(session_context) and not session_context.current_vendor_id:
+            return {"error": "Vendor session has no vendor identity — transfer rejected"}
+
         transfer_id = _generate_transfer_id()
 
         with db_session() as db:


### PR DESCRIPTION
## Summary
Fixes #324

Adds a pre-condition guard in `create_transfer` that rejects vendor-typed sessions with `current_vendor_id=None` before any transfer is initiated.

## Problem
`create_transfer` derived `vendor_id` solely from the tool argument and never validated the calling session's identity. A vendor portal session with `portal_type="vendor"` but `current_vendor_id=None` passed through silently, allowing unrestricted transfer capability against any vendor ID.

## Root Cause
No check existed on `session_context.current_vendor_id` before the transfer path. `_generate_transfer_id()` and `repo.create_transaction()` were reached unconditionally regardless of session completeness.

## Solution
Insert one guard at the top of `create_transfer`:
```python
if _is_vendor_session(session_context) and not session_context.current_vendor_id:
    return {"error": "Vendor session has no vendor identity — transfer rejected"}
```
The guard short-circuits before any DB write. All other session types are unaffected.

## Impact
- No breaking changes
- Minimal diff (1 guard, 2 lines)
- Deterministic behavior — error returned before side effects
- Zero regression risk for valid sessions

## Testing
```bash
# Must pass (bug fix)
pytest tests/unit/mcp/test_finstripe.py::TestVendorSessionAccessControl::test_mcp_vendor_007_vendor_session_without_vendor_id_calls_create_transfer -v

# Must continue passing (regression)
pytest tests/unit/mcp/test_finstripe.py::TestVendorSessionAccessControl::test_mcp_vendor_005 -v
```