### PR TITLE
Fix(finstripe): reject zero-and-negative amount transfers with pre-DB guard

### DIFF
--- a/finbot/mcp/servers/finstripe/server.py
+++ b/finbot/mcp/servers/finstripe/server.py
@@ -59,6 +59,9 @@ def create_finstripe_server(
         Transfers funds from the company account to a vendor's bank account.
         Returns the transfer details including a unique transfer ID for tracking.
         """
+        if amount <= 0:
+            return {"error": f"Invalid amount: {amount}. Amount must be greater than zero."}
+
         transfer_id = _generate_transfer_id()
 
         with db_session() as db:


### PR DESCRIPTION
## Summary
Fixes #334

Adds `amount <= 0` validation to `create_transfer`, blocking zero-amount
transactions before any DB write or transfer ID generation occurs.

## Problem
`create_transfer(amount=0.0, ...)` succeeded, creating a completed
transaction record — polluting audit logs with financially meaningless
entries and allowing invoice/vendor ID probing at zero cost.

## Root Cause
No amount validation existed in `create_transfer`. The function
called `_generate_transfer_id()` and `repo.create_transaction()`
unconditionally, regardless of amount value.

## Solution
Insert a two-line guard at function entry:
```python
if amount <= 0:
    return {"error": f"Invalid amount: {amount}. Amount must be greater than zero."}
```
Returns before any side-effectful call is made.

## Impact
- No breaking changes
- Minimal diff (2 lines added)
- Deterministic behavior
- Zero regression risk to valid-amount paths

## Testing
```bash
pytest tests/unit/mcp/test_finstripe.py::TestFloatEdgeCases::test_mcp_float_005_zero_amount_raises -v
pytest tests/unit/mcp/test_finstripe.py::TestFloatEdgeCases::test_mcp_float_001_max_payment_boundary_accepted -v
```