### PR TITLE
Fix(chat): resolve empty-string TIN bypass masking with is not None guard

### DIFF
--- a/finbot/agents/chat.py
+++ b/finbot/agents/chat.py
@@ -660,10 +660,9 @@ Current date: {datetime.now(UTC).strftime("%Y-%m-%d")}"""
     async def _call_get_vendor_details(self, vendor_id: int) -> str:
         result = await get_vendor_details(vendor_id, self.session_context)
         for key in ("tin", "bank_account_number", "bank_routing_number"):
-            if key in result and result[key]:
+            if key in result and result[key] is not None:
                 result[key] = "****" + str(result[key])[-4:]
         return json.dumps(result)
-
     async def _call_get_invoice_details(self, invoice_id: int) -> str:
         return json.dumps(await get_invoice_details(invoice_id, self.session_context))
 
@@ -1055,10 +1054,10 @@ Current date: {datetime.now(UTC).strftime("%Y-%m-%d")}"""
     async def _call_get_vendor_details(self, vendor_id: int) -> str:
         result = await get_vendor_details(vendor_id, self.session_context)
         for key in ("tin", "bank_account_number", "bank_routing_number"):
-            if key in result and result[key]:
+            if key in result and result[key] is not None:
                 result[key] = "****" + str(result[key])[-4:]
         return json.dumps(result)
-
+        
     async def _call_get_invoice_details(self, invoice_id: int) -> str:
         return json.dumps(await get_invoice_details(invoice_id, self.session_context))
 


### PR DESCRIPTION
## Summary
Fixes #408

Sensitive field masking skipped `""` and `0` values due to Python
truthiness evaluation. Replaces falsy check with explicit `is not None`.

## Problem
`if key in result and result[key]:` treats `""` as `False`, allowing
an empty-string TIN to bypass the masking pipeline and be returned raw.
Affects `tin`, `bank_account_number`, `bank_routing_number` in both
`VendorChatAssistant` and `CoPilotAssistant`.

## Root Cause
Truthiness guard `result[key]` evaluates falsy values (`""`, `0`) as
`False`, skipping the masking block entirely.

## Solution
Changed guard to `result[key] is not None` in both `_call_get_vendor_details`
implementations. Two-line diff, no other code touched.

## Impact
- No breaking changes
- Minimal diff (2 lines across 2 locations)
- Deterministic: all non-None sensitive fields now always masked
- Zero regression risk on non-empty values

## Testing
```bash
pytest tests/unit/agents/test_chat_assistant.py::TestQAFindings::test_chat_qa_002_empty_string_tin_not_masked -v
pytest tests/unit/agents/test_chat_assistant.py::TestQAFindings::test_chat_qa_003_integer_zero_tin_not_masked -v
pytest tests/unit/agents/test_chat_assistant.py -v
```