### PR TITLE
Fix: replace unused loop variable `round_idx` with `_` in stream_response

### DIFF
--- a/finbot/agents/chat.py
+++ b/finbot/agents/chat.py
@@ -315,7 +315,7 @@ class ChatAssistantBase:
         start_time = datetime.now(UTC)
 
         max_tool_rounds = 15
-        for round_idx in range(max_tool_rounds):
+        for _ in range(max_tool_rounds):
             stream_params = {
                 "model": self._model,
                 "input": input_messages,


### PR DESCRIPTION
### Fix: Remove unused loop variable `round_idx`

This PR replaces the unused loop variable `round_idx` with `_` in `ChatAssistantBase.stream_response` to follow Python conventions and improve code clarity.

### Changes:

* Updated loop from `for round_idx in range(max_tool_rounds)` to `for _ in range(max_tool_rounds)`

### Why:

* `round_idx` was defined but never used
* Using `_` clearly indicates an intentionally unused variable
* Avoids confusion for future contributors and satisfies linting rules

### Result:

* Cleaner and more readable code
* No functional changes

Please let me know if any changes are required. Thanks!
Closes #414