### PR TITLE
Fix(findrive): resolve path traversal validation gap in upload_file

### DIFF
--- a/finbot/mcp/servers/findrive/server.py
+++ b/finbot/mcp/servers/findrive/server.py
@@ -59,6 +59,9 @@ def create_findrive_server(
         if len(content.encode("utf-8")) > max_size:
             return {"error": f"File exceeds maximum size of {config.get('max_file_size_kb', 500)}KB"}
 
+        if ".." in filename or filename.startswith("/"):
+            return {"error": "filename contains invalid path traversal sequences"}
+
         with db_session() as db:
             repo = FinDriveFileRepository(db, session_context)
 


### PR DESCRIPTION
## Summary
Fixes #359
Rejects filenames containing `..` or a leading `/` before any database write occurs.

## Problem
`upload_file` accepted filenames such as `../../../etc/passwd` without validation,
passing them directly to `repo.create_file()`. If filenames are used in filesystem
operations downstream, this enables directory escape and arbitrary file read/write.

## Root Cause
No path traversal check existed between parameter ingestion and `repo.create_file()`.
The size check was the only guard; filename content was entirely trusted.

## Solution
Added two-condition guard immediately after the size check:
```python
if ".." in filename or filename.startswith("/"):
    return {"error": "filename contains invalid path traversal sequences"}
```
Consistent with existing early-return error style. No other lines changed.

## Impact
- No breaking changes
- Minimal diff (2 lines added)
- Deterministic rejection behavior
- Zero regression risk

## Testing
```bash
pytest tests/unit/mcp/test_findrive.py::TestFileNameValidation::test_fd_fname_002_path_traversal_in_filename_accepted -v
pytest tests/unit/mcp/test_findrive.py::TestUploadFile::test_fd_upload_001_upload_returns_file_id_and_metadata -v
```