### PR TITLE
Fix(findrive): reject empty/whitespace filenames before DB write in upload_file

### DIFF
--- a/finbot/mcp/servers/findrive/server.py
+++ b/finbot/mcp/servers/findrive/server.py
@@ -55,6 +55,9 @@ def create_findrive_server(
         retrieval. Use this for storing invoice PDFs, receipts, and supporting
         documentation.
         """
+        if not filename or not filename.strip():
+            return {"error": "Filename must not be empty"}
+
         max_size = config.get("max_file_size_kb", 500) * 1024
         if len(content.encode("utf-8")) > max_size:
             return {"error": f"File exceeds maximum size of {config.get('max_file_size_kb', 500)}KB"}


### PR DESCRIPTION
## Summary
Fixes #366

Adds missing filename presence validation to `upload_file`, preventing
ghost records from being created with empty or whitespace-only filenames.

## Problem
`upload_file(filename='', content='data')` bypassed all validation and
called `repo.create_file(filename='', ...)`, persisting an unresolvable
record in the file index.

## Root Cause
`upload_file` validated `content` size but had no guard on `filename`,
allowing empty strings to reach the repository layer unconditionally.

## Solution
Added a two-condition guard (`not filename or not filename.strip()`) as
the first check in `upload_file`, returning `{"error": "Filename must
not be empty"}` before any DB interaction occurs.

## Impact
- No breaking changes
- Minimal diff (+2 lines, 0 removed)
- Deterministic early return on invalid input
- Zero regression risk to valid upload paths

## Testing
```bash
pytest tests/unit/mcp/test_findrive.py::TestUploadFile::test_fd_upload_007_empty_filename_accepted_without_validation -v
pytest tests/unit/mcp/test_findrive.py::TestUploadFile::test_fd_upload_001_upload_returns_file_id_and_metadata -v
```