### PR TITLE
DOC: Fix broken markdown link formatting for .env.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Platform runs at [http://localhost:8000](http://localhost:8000)
 
 ## Configuration
 
-Key environment variables (see `[.env.example](.env.example)` for the full template):
+Key environment variables (see [.env.example](.env.example) for the full template):
 
 
 | Variable         | Default                  | Description                        |


### PR DESCRIPTION
Moved backticks inside the brackets to restore the clickable hyperlink for the .env.example file.