### PR TITLE
Fix(findrive): resolve missing negative-limit guard in search_files

### DIFF
--- a/finbot/mcp/servers/findrive/server.py
+++ b/finbot/mcp/servers/findrive/server.py
@@ -177,6 +177,9 @@ def create_findrive_server(
         Returns documents whose filename or extracted text matches the query.
         Useful for finding relevant invoice PDFs and supporting documents.
         """
+        if limit < 0:
+            return {"error": f"limit must be non-negative, got {limit}"}
+
         with db_session() as db:
             repo = FinDriveFileRepository(db, session_context)
             files = repo.search_files(query, limit=limit)


### PR DESCRIPTION
## Summary
Fixes #353  `search_files` accepted negative `limit` values and forwarded them directly to the database layer, triggering undefined SQL `LIMIT` behavior.

## Root Cause
No lower-bound validation existed on the `limit` parameter in `search_files`. The raw value was passed unchecked into `repo.search_files(query, limit=limit)`.

## Solution
Added a two-line early-return guard at the top of `search_files`, before the `db_session` block, that returns a structured error response when `limit < 0`. Matches the existing error-return pattern used in `upload_file`.
```python
if limit < 0:
    return {"error": f"limit must be non-negative, got {limit}"}
```

## Impact
- No breaking changes
- Deterministic error response for invalid input
- Zero change to the valid-input path

## Testing
```bash
pytest tests/unit/mcp/test_findrive.py::TestIntFieldEdgeCases::test_fd_int_006_search_files_negative_limit_raises -v
pytest tests/unit/mcp/test_findrive.py::test_fd_srch_001_returns_matching_files_by_filename -v
```

## Tasks
- [x] Root cause identified (`limit` forwarded to DB without validation)
- [x] Guard added before `db_session` block in `search_files`
- [x] Error response matches existing pattern in `upload_file`
- [x] Negative limit test passes (`test_fd_int_006_search_files_negative_limit_raises`)
- [x] Valid search regression test passes (`test_fd_srch_001_returns_matching_files_by_filename`)