### PR TITLE
Fix(findrive): reject empty/whitespace content in upload_file before DB write

### DIFF
--- a/finbot/mcp/servers/findrive/server.py
+++ b/finbot/mcp/servers/findrive/server.py
@@ -55,10 +55,12 @@ def create_findrive_server(
         retrieval. Use this for storing invoice PDFs, receipts, and supporting
         documentation.
         """
+        if not content or not content.strip():
+            return {"error": "File content must not be empty"}
+
         max_size = config.get("max_file_size_kb", 500) * 1024
         if len(content.encode("utf-8")) > max_size:
             return {"error": f"File exceeds maximum size of {config.get('max_file_size_kb', 500)}KB"}
-
         with db_session() as db:
             repo = FinDriveFileRepository(db, session_context)
 


### PR DESCRIPTION
## Summary

Fixes #367

Adds a content presence guard in `upload_file` to reject empty or whitespace-only
content before the size check and any database interaction occurs.

---

## Problem

`upload_file` in `finbot/mcp/servers/findrive/server.py` accepted `content=''`
silently and persisted a record with `file_size=0` and blank `content_text`.

The existing guard only checks the **upper bound** (file too large), not the
**lower bound** (file is empty):
```python
# 0 > max_size is always False  empty string passes straight through
if len(content.encode("utf-8")) > max_size:
    return {"error": "..."}

f = repo.create_file(content_text=content, ...)  # written with content_text=''
```

When a downstream agent later calls `get_file`, it receives `extracted_text: ""`
with no error signal  a silent failure that can corrupt agent decision-making.

---

## Root Cause

**This occurs because** the `max_size` guard evaluates `len("".encode()) > max_size`
as `0 > 512000` → `False`, **which leads to** `repo.create_file()` being reached
with empty `content_text` and `file_size` stored as `0`.

**Classification:** Validation gap  missing presence check before the size guard.

---

## Solution

Two lines inserted **immediately before** the `max_size` guard, inside `upload_file`:
```python
if not content or not content.strip():
    return {"error": "File content must not be empty"}
```

- `not content` catches `""` and `None`
- `not content.strip()` catches whitespace-only strings (`"   "`, `"\n\t"`, etc.)
- Returns early before **any** DB interaction occurs
- Error dict shape is consistent with all other early-return guards in the same function

No other lines were modified.

---

## Behaviour Comparison

| Input | Before | After |
|---|---|---|
| `content=""` | `{"file_id": ..., "file_size": 0, "status": "uploaded"}` | `{"error": "File content must not be empty"}` |
| `content="   "` | `{"file_id": ..., "file_size": 0, "status": "uploaded"}` | `{"error": "File content must not be empty"}` |
| `content="valid text"` |  Uploaded normally |  Uploaded normally (unchanged) |
| `content` exceeds 500 KB | Size error returned | Size error returned (unchanged) |

---

## Impact

- **No breaking changes**  valid non-empty content hits the exact same code path as before
- **No DB writes** on invalid input  guard fires before `repo.create_file()`
- **Minimal diff**  2 lines added, 0 lines removed or modified elsewhere
- **Consistent API contract**  return type remains `dict[str, Any]`; error shape matches existing guards

---

## Testing
```bash
# Must pass (the reported regression)
pytest tests/unit/mcp/test_findrive.py::TestUploadFile::test_fd_upload_008_empty_content_accepted_without_validation -v

# Must continue to pass (existing happy path)
pytest tests/unit/mcp/test_findrive.py::TestUploadFile::test_fd_upload_001_upload_returns_file_id_and_metadata -v
```

---

## Tasks

- [x] Identified root cause: missing lower-bound presence check before `max_size` guard
- [x] Confirmed `0 > max_size` always evaluates `False`, bypassing validation entirely
- [x] Added `not content or not content.strip()` guard covering empty and whitespace-only inputs
- [x] Verified guard fires before any `db_session` or `repo.create_file()` call
- [x] Confirmed error dict shape matches existing guards in `upload_file`
- [x] Confirmed no other code paths, functions, or files were modified
- [x] `test_fd_upload_008_empty_content_accepted_without_validation` passes
- [x] `test_fd_upload_001_upload_returns_file_id_and_metadata` continues to pass