### PR TITLE
Fix(chat): resolve response_complete event/DB inconsistency on attachments

### DIFF
--- a/finbot/agents/chat.py
+++ b/finbot/agents/chat.py
@@ -446,7 +446,7 @@ class ChatAssistantBase:
                 "response_length": len(full_response),
                 "response_content": full_response,
                 "duration_ms": duration_ms,
-                "user_message": user_message,
+                "user_message": effective_message,
                 "vendor_id": self.session_context.current_vendor_id,
                 "llm_model": self._model,
             },


### PR DESCRIPTION
## Summary

Fixes #413

Resolves a data consistency bug where the `response_complete` event emitted to Redis
contained the original `user_message`, while the DB record saved `effective_message`
(the attachment-prefixed version). Any session with attachments produced mismatched
records between the event log and the database.

---

## Context

`stream_response` constructs `effective_message` by prepending a FinDrive file reference
header when attachments are present:
```python
effective_message = (
    f"[User attached FinDrive files: {file_refs}]\n\n{user_message}"
)
```

This `effective_message` is what gets:
- passed to the LLM as actual input
- saved to the DB via `_save_message("user", effective_message)`

However, the `response_complete` event was emitting `user_message`, the raw, unprefixed
original, making it diverge from every other record of what was actually processed.

The `message_received` event correctly and intentionally emits `user_message` to capture
what the user literally typed. The `response_complete` event should mirror what was
**processed**, which is `effective_message`.

---

## Root Cause
```python
# finbot/agents/chat.py  response_complete event (line 449)
event_data={
    ...
    "user_message": user_message,   # ← wrong: original, not what LLM received
    ...
}
```

`effective_message` was already in scope and correctly used everywhere else.
This was a straight omission  the wrong variable was referenced.

---

## Fix

**`finbot/agents/chat.py`**
```diff
 event_data={
     "response_length": len(full_response),
     "response_content": full_response,
     "duration_ms": duration_ms,
-    "user_message": user_message,
+    "user_message": effective_message,
     "vendor_id": self.session_context.current_vendor_id,
     "llm_model": self._model,
 },
```

`effective_message` is unconditionally assigned before this point:
- **No attachments:** `effective_message = user_message` → identical value, zero regression
- **With attachments:** `effective_message` carries the prefix → event now matches DB

---

## Impact

- **Compliance audits** comparing event logs to DB records will no longer find spurious
  mismatches on attachment sessions
- **Session replay and debug tooling** using event logs will now reflect the exact input
  the LLM processed
- No schema changes, no API contract changes, no behavioral change on attachment-free paths

---

## Testing
```bash
pytest tests/integration/agents/test_chat_layer3.py::TestL3QAFindings::test_chat_l3_qa_002_event_data_logs_original_message_not_effective -v
```

Regression (no-attachment paths):
```bash
pytest tests/integration/agents/test_chat_layer3.py -v -k "not qa_002"
```

---

## Tasks

- [x] Identified exact divergence point between DB write and event emission in `stream_response`
- [x] Confirmed `effective_message` is unconditionally in scope before the `response_complete` emit
- [x] Confirmed `message_received` event intentionally retains `user_message`  left untouched
- [x] Verified no-attachment path is regression-safe (`effective_message == user_message` when `attachments` is falsy)
- [x] Single-line fix applied in `response_complete` event payload
- [x] Existing integration test `test_chat_l3_qa_002` validates the corrected behaviour