### PR TITLE
Fix(finstripe): reject non-positive amounts in create_transfer before DB insert

### DIFF
--- a/finbot/mcp/servers/finstripe/server.py
+++ b/finbot/mcp/servers/finstripe/server.py
@@ -59,6 +59,9 @@ def create_finstripe_server(
         Transfers funds from the company account to a vendor's bank account.
         Returns the transfer details including a unique transfer ID for tracking.
         """
+        if amount <= 0:
+            return {"error": "amount must be greater than zero"}
+
         transfer_id = _generate_transfer_id()
 
         with db_session() as db:


### PR DESCRIPTION
## Summary

Fixes #333

Prevents `create_transfer` from persisting transactions with `amount <= 0` by adding an
early-return guard before any DB interaction or transfer ID generation.

---

## Problem

`create_transfer` performed no input validation on the `amount` parameter. Any caller 
including an AI agent  could pass a negative or zero value and receive a `"completed"`
transaction record in return.

This opened a direct path to:
- **Phantom reversals**  negative amounts recorded as legitimate outbound transfers
- **Unauthorized refunds**  no approval flow triggered, no rejection signal returned

The root issue was not in the DB layer or the repository  the repository does exactly
what it's told. The bug lived entirely at the **entry point of the tool**, where the
contract was never enforced.

---

## Root Cause
```python
# No validation here  amount flows directly into the DB
transfer_id = _generate_transfer_id()

with db_session() as db:
    repo = PaymentTransactionRepository(db, session_context)
    txn = repo.create_transaction(
        ...
        amount=amount,   # -1.0 accepted without complaint
        ...
        status="completed",
    )
```

`amount` was never checked before `_generate_transfer_id()` was called and the DB
session was opened. A negative value reached `repo.create_transaction()` and was
written as a `"completed"` transfer  indistinguishable from a legitimate one.

---

## Solution

Insert a two-line guard at the top of `create_transfer`, before any side-effectful
operation:
```python
if amount <= 0:
    return {"error": "amount must be greater than zero"}

transfer_id = _generate_transfer_id()   # only reached for valid amounts
```

**Why here, not deeper:**
Validating at the entry point means zero DB writes, zero IDs generated, and zero log
noise for invalid input. Pushing this check deeper (e.g., into the repository) would
hide a business rule inside infrastructure code.

**Why `<= 0` and not `< 0`:**
A zero-amount transfer is economically meaningless and equally exploitable as a
negative one  both are rejected.

**Pattern consistency:**
The error dict shape `{"error": "..."}` matches the existing convention in
`get_transfer`, keeping the tool's failure contract uniform.

---

## Impact

-  No breaking changes  the valid-amount execution path is completely untouched
-  Minimal diff  two lines added, zero lines modified or removed elsewhere  
-  No new dependencies, no imports, no schema changes
-  `max_payment` boundary check continues to work as before for positive amounts
-  Error response shape is consistent with existing tool error patterns

---

## Testing

**Failing case (the bug):**
```bash
pytest tests/unit/mcp/test_finstripe.py::TestFloatEdgeCases::test_mcp_float_004_negative_amount_raises -v
```
Before fix → test fails (transfer record created).  
After fix → `{"error": "amount must be greater than zero"}` returned, test passes.

**Regression guard:**
```bash
pytest tests/unit/mcp/test_finstripe.py::TestFloatEdgeCases::test_mcp_float_001_max_payment_boundary_accepted -v
```
Confirms the valid positive-amount path is unaffected.

---

## Tasks

- [x] Identified missing input validation in `create_transfer` as the sole root cause
- [x] Confirmed bug scope is limited to `finbot/mcp/servers/finstripe/server.py`
- [x] Added `amount <= 0` guard before `_generate_transfer_id()` and `db_session` entry
- [x] Verified error response shape matches existing `get_transfer` convention
- [x] Confirmed zero-amount case is covered by the `<= 0` boundary (not just `< 0`)
- [x] Verified `max_payment` check and all downstream logic are unaffected
- [x] `test_mcp_float_004_negative_amount_raises` passes
- [x] `test_mcp_float_001_max_payment_boundary_accepted` continues to pass