### PR TITLE
fix(ctf): align profile/share hint-cost scoring with stats endpoint

### DIFF
--- a/finbot/apps/ctf/routes/profile.py
+++ b/finbot/apps/ctf/routes/profile.py
@@ -441,18 +441,19 @@ async def get_public_profile(
     challenge_repo = ChallengeRepository(db)
     badge_repo = BadgeRepository(db)
 
-    # Query completed challenges for this user
+    # Load all progress rows for consistent profile stats with /api/v1/stats.
     from finbot.core.data.models import UserChallengeProgress, UserBadge
 
-    completed_progress = (
+    all_progress = (
         db.query(UserChallengeProgress)
         .filter(
             UserChallengeProgress.namespace == owner_namespace,
             UserChallengeProgress.user_id == profile.user_id,
-            UserChallengeProgress.status == "completed",
         )
         .all()
     )
+    completed_progress = [p for p in all_progress if p.status == "completed"]
+    hints_cost = sum(p.hints_cost for p in all_progress)
 
     # Get badge data
     earned_badges = (
@@ -468,7 +469,6 @@ async def get_public_profile(
     # Calculate points
     challenge_points = challenge_repo.get_effective_points(completed_progress)
     badge_points = badge_repo.get_total_points(earned_badge_ids)
-    hints_cost = sum(p.hints_cost for p in completed_progress)
     total_points = challenge_points + badge_points - hints_cost
 
     # Get totals

--- a/finbot/apps/ctf/routes/share.py
+++ b/finbot/apps/ctf/routes/share.py
@@ -194,15 +194,16 @@ async def get_profile_card(
     if not profile or not user:
         raise HTTPException(status_code=404, detail="Profile not found")
 
-    completed_progress = (
+    all_progress = (
         db.query(UserChallengeProgress)
         .filter(
             UserChallengeProgress.namespace == user.namespace,
             UserChallengeProgress.user_id == profile.user_id,
-            UserChallengeProgress.status == "completed",
         )
         .all()
     )
+    completed_progress = [p for p in all_progress if p.status == "completed"]
+    hints_cost = sum(p.hints_cost for p in all_progress)
 
     earned_badges = (
         db.query(UserBadge)
@@ -219,7 +220,6 @@ async def get_profile_card(
     challenge_points = challenge_repo.get_effective_points(completed_progress)
     earned_badge_ids = [b.badge_id for b in earned_badges]
     badge_points = badge_repo.get_total_points(earned_badge_ids)
-    hints_cost = sum(p.hints_cost for p in completed_progress)
     total_points = challenge_points + badge_points - hints_cost
 
     level, level_title = calculate_level(total_points)

--- a/finbot/apps/ctf/routes/web.py
+++ b/finbot/apps/ctf/routes/web.py
@@ -152,15 +152,16 @@ async def ctf_public_profile(
         challenge_repo = ChallengeRepository(db)
         badge_repo = BadgeRepository(db)
 
-        completed_progress = (
+        all_progress = (
             db.query(UserChallengeProgress)
             .filter(
                 UserChallengeProgress.namespace == user.namespace,
                 UserChallengeProgress.user_id == profile.user_id,
-                UserChallengeProgress.status == "completed",
             )
             .all()
         )
+        completed_progress = [p for p in all_progress if p.status == "completed"]
+        hints_cost = sum(p.hints_cost for p in all_progress)
         earned_badge_ids = [
             b.badge_id
             for b in db.query(UserBadge)
@@ -176,7 +177,7 @@ async def ctf_public_profile(
         total_points = (
             challenge_repo.get_effective_points(completed_progress)
             + badge_repo.get_total_points(earned_badge_ids)
-            - sum(p.hints_cost for p in completed_progress)
+            - hints_cost
         )
         level, level_title = calculate_level(total_points)
         bio = profile.bio or "AI Security Enthusiast"


### PR DESCRIPTION
close #465 
**What changed**

- Updated profile/share scoring paths to load all progress rows for the user.
- Kept completion metrics based on `status == "completed"` for completion-related counts.
- Calculated `hints_cost` from all progress rows so point deductions match `/api/v1/stats`.

**Impact**
- total_points displayed in profile/share now matches stats behavior.
- No intended change to completion counts, category progress logic, or activity feed semantics.



https://github.com/user-attachments/assets/a3ee153d-6062-4682-a78f-3f4718749d9b


