### PR TITLE
ui: fix mobile responsiveness and viewport scaling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
         condition: service_healthy
         required: false
     volumes:
+      - ./finbot:/app/finbot
       - sqlite_data:/app/data
       - uploads:/app/uploads
       - cache:/app/cache

--- a/finbot/apps/finbot/templates/base.html
+++ b/finbot/apps/finbot/templates/base.html
@@ -62,12 +62,16 @@
             background: linear-gradient(135deg, #00d4ff 0%, #7c3aed 50%, #06ffa5 100%);
             -webkit-background-clip: text; background-clip: text;
             -webkit-text-fill-color: transparent;
+            box-decoration-break: clone;
+            -webkit-box-decoration-break: clone;
         }
 
         .gradient-text-alt {
             background: linear-gradient(90deg, #00d4ff, #06ffa5);
             -webkit-background-clip: text; background-clip: text;
             -webkit-text-fill-color: transparent;
+            box-decoration-break: clone;
+            -webkit-box-decoration-break: clone;
         }
 
         {% block extra_css %}{% endblock %}
@@ -88,7 +92,7 @@
                     <span class="text-cyan text-[10px] font-mono tracking-widest ml-1.5 hidden sm:inline">CTF</span>
                 </div>
             </a>
-            <nav class="flex items-center space-x-1 sm:space-x-2">
+            <nav class="flex items-center space-x-3 sm:space-x-2">
                 {% block nav %}
                 <a href="/" class="text-text-3 hover:text-cyan transition text-sm px-3 py-2 rounded-lg hover:bg-white/[0.03]">Home</a>
                 <a href="/how-it-works" class="text-text-3 hover:text-cyan transition text-sm px-3 py-2 rounded-lg hover:bg-white/[0.03] hidden sm:inline-flex">How It Works</a>

--- a/finbot/apps/finbot/templates/home.html
+++ b/finbot/apps/finbot/templates/home.html
@@ -65,7 +65,7 @@
 
 {% block content %}
         <!-- Hero -->
-        <section class="relative pt-32 pb-20 px-6">
+        <section class="relative pt-32 pb-20 px-6 overflow-hidden">
             <div class="hero-glow"></div>
             <div class="max-w-5xl mx-auto text-center relative">
                 <a href="https://genai.owasp.org/" target="_blank" rel="noopener" class="owasp-badge inline-flex items-center space-x-3 px-5 py-2.5 rounded-full glass border border-border-dim mb-10">
@@ -82,7 +82,7 @@
                     </div>
                 </div>
 
-                <h1 class="text-5xl sm:text-6xl md:text-7xl font-black text-text-1 tracking-tight mb-6 leading-[1.1]">
+                <h1 class="text-4xl sm:text-6xl md:text-7xl font-black text-text-1 tracking-tight mb-6 leading-[1.1]">
                     Hack the Agents.<br>
                     <span class="gradient-text">Secure the Future.</span>
                 </h1>
@@ -108,11 +108,11 @@
         </section>
 
         <!-- What is FinBot -->
-        <section id="about" class="py-20 px-6">
+        <section id="about" class="py-20 px-6 overflow-hidden">
             <div class="max-w-6xl mx-auto">
                 <div class="text-center mb-14">
                     <p class="font-mono text-cyan text-xs tracking-widest uppercase mb-3">What is OWASP FinBot?</p>
-                    <h2 class="text-3xl sm:text-4xl font-bold text-text-1">An Agentic AI vendor management platform.<br class="hidden sm:block"> <span class="gradient-text-alt">Intentionally vulnerable.</span></h2>
+                    <h2 class="text-2xl sm:text-4xl font-bold text-text-1">An Agentic AI vendor management platform.<br class="hidden sm:block"> <span class="gradient-text-alt whitespace-nowrap">Intentionally vulnerable.</span></h2>
                 </div>
 
                 <div class="grid md:grid-cols-3 gap-6">


### PR DESCRIPTION
# Pull Request: [UI/UX] Improve Mobile Responsiveness and Fix Initial Viewport Scaling

## Summary
This PR addresses several critical UI/UX issues on the landing page, specifically targeting mobile viewports (390px and below). It fixes a persistent "Initial Zoom" bug and optimizes typography and layout for better accessibility.

## Changes
- **Fixed Initial Zoom Bug**: Added `overflow-hidden` to the Hero and About sections. This prevents wide decorative glows (800px radial gradients) from extending beyond the viewport, which previously caused browsers to incorrectly scale the page on load.
- **Responsive Typography Scaling**:
    - Reduced Hero heading font size from `text-4xl` on the smallest screens (down from `text-5xl`).
    - Reduced "What is OWASP FinBot?" section heading to `text-2xl` on mobile.
- **Improved Layout & Wrapping**:
    - Added `whitespace-nowrap` to key phrases to prevent awkward line breaks on mobile.
    - Increased navbar item spacing (`space-x-3`) to improve touch-target accessibility.
- **Gradient Rendering Fix**: Added `box-decoration-break: clone` to the `gradient-text` classes to ensure gradients render continuously across multiple lines of wrapped text.
- **DevX Improvement**: Updated `docker-compose.yml` with a volume mapping for the `finbot` directory to enable live-reloading during development.

## Bug Fixes
- Fixes the issue where the page loads at ~150% zoom on mobile devices.
- Fixes crowded navbar elements on 390px width devices.
- Fixes inconsistent line breaks in descriptive headings.

## Demonstration

https://github.com/user-attachments/assets/61402195-60e5-447c-a294-a3d04d1cffa9






## Contribution Rules Check
- [x] Branch: `fix/mobile-responsiveness`
- [x] Style: Black/isort rules followed (templates only)
- [x] Tested locally via Docker with volume mapping





**fixes #487**